### PR TITLE
Speed up import with cffi 0.6.

### DIFF
--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -33,7 +33,7 @@ def dlopen(ffi, *names):
 
 ffi = FFI()
 ffi.cdef(_CAIRO_HEADERS)
-cairo = dlopen(ffi, 'cairo', 'libcairo-2')
+cairo = dlopen(ffi, 'libcairo.so.2', 'libcairo-2.dll', 'cairo', 'libcairo-2')
 
 
 class CairoError(Exception):


### PR DESCRIPTION
Since 0.6 cffi will try to pass the library name directly to dlopen without searching. So pass the exact names first. Saves 15 ms here.
