### PR TITLE
Pycairo C API support

### DIFF
--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -22,6 +22,10 @@ VERSION = '0.5.1'
 version = '1.10.0'
 version_info = (1, 10, 0)
 
+# This will hold a PyCapsule compatible with the Pycairo CAPI
+# after enable_capi() is called.
+CAPI = None
+
 
 def dlopen(ffi, *names):
     """Try various names for the same library, for different platforms."""
@@ -93,6 +97,18 @@ def install_as_pycairo():
 
     """
     sys.modules['cairo'] = sys.modules[__name__]
+
+
+def enable_capi():
+    """Enable C API compatible with Pycairo
+
+    This calls "install_as_pycairo()" because it is a requirement.
+    See help(cairocffi.capi) for more details.
+    """
+    from . import capi
+    global CAPI
+    CAPI = capi.CAPI
+    install_as_pycairo()
 
 
 # Implementation is in submodules, but public API is all here.

--- a/cairocffi/capi.py
+++ b/cairocffi/capi.py
@@ -1,0 +1,191 @@
+# coding: utf8
+#
+# cairocffi.capi
+# ~~~~~~~~~~~~~~~~~
+#
+# :copyright: Copyright 2013 by Simon Feltman
+# :license: BSD, see LICENSE for details.
+
+"""
+Mostly ABI compatible Pycairo C API
+
+This modules exposes a PyCapsule as "CAPI" which can be installed using
+cairocffi.enable_capi().
+
+The Pycairo C API looks for the capsule in a module named "cairo",
+so cairocffi.enable_capi() installs cairocffi into sys.modules
+as "cairo". The capsule holds a table of pointers to functions and
+Python types which is mostly ABI compatible with what Pycairo supplies.
+The exception being attempts to access returned wrapper struct members
+of the PyObjects supplied by this API, e.g:
+
+    PyObject *pyctx = Context_FromContext (ctx);
+    ((PycairoContext*)pyctx)->ctx
+
+Extensions which do this will crash due to the actual PyObjects returned
+from Pycairo and cairocffi not being binary compatible.
+
+This only works with cpython and will raise an import error otherwise.
+"""
+
+import sys
+if sys.implementation.name != 'cpython':
+    raise ImportError('Cannot use cairo C API with implementations other than cpython')
+
+from . import ffi, cairo, _check_status, dlopen
+
+from .surfaces import (Surface, ImageSurface, PDFSurface, PSSurface,
+                       SVGSurface, RecordingSurface)
+from .patterns import (Pattern, SolidPattern, SurfacePattern,
+                       Gradient, LinearGradient, RadialGradient)
+from .fonts import FontFace, ToyFontFace, ScaledFont, FontOptions
+from .context import Context
+from .matrix import Matrix
+
+
+# cffi python api
+Python_CAPI = """
+typedef struct PyObject PyObject;
+typedef struct PyTypeObject PyTypeObject;
+PyObject* PyCapsule_New(void *pointer, const char *name, void*);
+void* PyCapsule_GetPointer(PyObject *capsule, const char *name);
+void Py_IncRef(PyObject *o);
+void Py_DecRef(PyObject *o);
+"""
+ffi.cdef(Python_CAPI)
+_dlname = 'libpython%i.%i%s.so' % (sys.version_info[:2] + (sys.abiflags,))
+pythoncffi = dlopen(ffi, _dlname)
+
+
+def CPyObjectWrapper_ForCairoPtr(tp, cairo_ptr):
+    # We must add an additional ref to the newly created PyObject which
+    # is handed back to the calling C API. This needs to return
+    # a "New value reference". Otherwise the refcount of "wrapper"
+    # will go to zero at the end of this function.
+    wrapper = tp._from_pointer(cairo_ptr, True)
+    wrapperptr = ffi.cast('PyObject*', id(wrapper))
+    pythoncffi.Py_IncRef(wrapperptr)
+    return wrapperptr
+
+
+@ffi.callback("PyObject*(*)(cairo_t*, PyTypeObject*, PyObject*)")
+def Context_FromContext(ctx, tp, base):
+    return CPyObjectWrapper_ForCairoPtr(Context, ctx)
+
+
+@ffi.callback("PyObject*(*)(cairo_font_face_t*)")
+def FontFace_FromFontFace(font_face):
+    return CPyObjectWrapper_ForCairoPtr(FontFace, font_face)
+
+
+@ffi.callback("PyObject*(*)(cairo_font_options_t*)")
+def FontOptions_FromFontOptions(font_options):
+    return CPyObjectWrapper_ForCairoPtr(FontOptions, font_options)
+
+
+@ffi.callback("PyObject*(*)(const cairo_matrix_t*)")
+def Matrix_FromMatrix(matrix):
+    return CPyObjectWrapper_ForCairoPtr(Matrix, matrix)
+
+
+@ffi.callback("PyObject*(*)(cairo_path_t*)")
+def Path_FromPath(path):
+    return CPyObjectWrapper_ForCairoPtr(Path, path)
+
+
+@ffi.callback("PyObject*(*)(cairo_pattern_t*, PyObject*)")
+def Pattern_FromPattern(pattern, base):
+    return CPyObjectWrapper_ForCairoPtr(Pattern, pattern)
+
+
+@ffi.callback("PyObject*(*)(cairo_scaled_font_t*)")
+def ScaledFont_FromScaledFont(scaled_font):
+    return CPyObjectWrapper_ForCairoPtr(ScaledFont, scaled_font)
+
+
+@ffi.callback("PyObject*(*)(cairo_surface_t*, PyObject*)")
+def Surface_FromSurface(surface):
+    return CPyObjectWrapper_ForCairoPtr(Surface, surface)
+
+
+@ffi.callback("PyObject*(*)(cairo_rectangle_int_t*)")
+def RectangleInt_FromRectangleInt(rectangle_int):
+    return CPyObjectWrapper_ForCairoPtr(RectangleInt, rectangle_int)
+
+
+@ffi.callback("PyObject*(*)(cairo_region_t*)")
+def Region_FromRegion(region):
+    return CPyObjectWrapper_ForCairoPtr(Region, region)
+
+
+@ffi.callback("int(*)(cairo_status_t)")
+def Check_Status(status):
+    return _check_status(status)
+
+
+# Note: this must match the layout of the Pycairo_CAPI_t
+# found in pycairo.h and py3cairo.h
+# Todo: perhaps this should parse a copy of the Pycairo_CAPI_t and
+# use ffi.verify with pycairo.h
+_pointers = [ffi.cast('PyTypeObject*', id(Context)),
+             Context_FromContext,
+             ffi.cast('PyTypeObject*', id(FontFace)),
+             ffi.cast('PyTypeObject*', id(ToyFontFace)),
+             FontFace_FromFontFace,
+             ffi.cast('PyTypeObject*', id(FontOptions)),
+             FontOptions_FromFontOptions,
+             ffi.cast('PyTypeObject*', id(Matrix)),
+             Matrix_FromMatrix,
+             ffi.NULL,  # ffi.cast('PyTypeObject*', id(Path)),
+             ffi.NULL,  # Path_FromPath,
+             ffi.cast('PyTypeObject*', id(Pattern)),
+             ffi.cast('PyTypeObject*', id(SolidPattern)),
+             ffi.cast('PyTypeObject*', id(SurfacePattern)),
+             ffi.cast('PyTypeObject*', id(Gradient)),
+             ffi.cast('PyTypeObject*', id(LinearGradient)),
+             ffi.cast('PyTypeObject*', id(RadialGradient)),
+             Pattern_FromPattern,
+             ffi.cast('PyTypeObject*', id(ScaledFont)),
+             ScaledFont_FromScaledFont,
+             ffi.cast('PyTypeObject*', id(Surface)),
+             ffi.cast('PyTypeObject*', id(ImageSurface)),
+             ffi.cast('PyTypeObject*', id(PDFSurface)),
+             ffi.cast('PyTypeObject*', id(PSSurface)),
+             ffi.cast('PyTypeObject*', id(RecordingSurface)),
+             ffi.cast('PyTypeObject*', id(SVGSurface)),
+             ffi.NULL,  # ffi.cast('PyTypeObject*', id(Win32Surface)),
+             ffi.NULL,  # ffi.cast('PyTypeObject*', id(Win32PrintingSurface)),
+             ffi.NULL,  # ffi.cast('PyTypeObject*', id(XCBSurface)),
+             ffi.NULL,  # ffi.cast('PyTypeObject*', id(XlibSurface)),
+             Surface_FromSurface,
+             Check_Status,
+             ffi.NULL,  # ffi.cast('PyTypeObject*', id(RectangleInt)),
+             ffi.NULL,  # RectangleInt_FromRectangleInt,
+             ffi.NULL,  # ffi.cast('PyTypeObject*', id(Region)),
+             Region_FromRegion,
+            ]
+
+
+# We must use ctypes to create a valid PyCapsule
+import ctypes
+
+ctypes.pythonapi.PyCapsule_New.restype = ctypes.py_object
+ctypes.pythonapi.PyCapsule_New.argtypes = (ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p)
+ctypes.pythonapi.PyCapsule_GetPointer.restype = ctypes.c_void_p
+ctypes.pythonapi.PyCapsule_GetPointer.argtypes = (ctypes.py_object, ctypes.c_char_p)
+
+
+# Stash these at the module level to ensure they are kept alive
+_pycairo_api = ffi.new("void*[%i]" % len(_pointers), _pointers)
+_capsule_name = b'cairo.CAPI'
+_pycairo_api_addr = int(ffi.cast('uintptr_t', _pycairo_api))
+CAPI = ctypes.pythonapi.PyCapsule_New(_pycairo_api_addr, _capsule_name, None)
+
+# Failed attempt at using cffi to create the PyCapsule
+# (ffi.from_handle did not do what I expected)
+"""
+_capsule_name = ffi.NULL  # b'cairo.CAPI'
+_capsule = pythoncffi.PyCapsule_New(_pycairo_api, _capsule_name, ffi.NULL)
+_capsule_addr = int(ffi.cast('uintptr_t', _capsule))
+CAPI = ffi.from_handle(ffi.cast('void*', _capsule_addr))
+"""

--- a/cairocffi/context.py
+++ b/cairocffi/context.py
@@ -100,8 +100,13 @@ class Context(object):
     def __init__(self, target):
         self._init_pointer(cairo.cairo_create(target._pointer))
 
+    def __del__(self):
+        cairo.cairo_destroy(self._pointer)
+
     def _init_pointer(self, pointer):
-        self._pointer = ffi.gc(pointer, cairo.cairo_destroy)
+        # let __del__ handle destroy so wrappers created with _from_pointer
+        # also manage the a ref
+        self._pointer = ffi.gc(pointer, lambda ptr: None)
         self._check_status()
 
     def _check_status(self):

--- a/cairocffi/example_capi.py
+++ b/cairocffi/example_capi.py
@@ -1,0 +1,66 @@
+"""
+GTK+ 3 example using a drawing area to draw with cairocffi.
+
+Drawing code taken from:
+http://cairographics.org/pycairo/tutorial/
+"""
+
+import sys
+import math
+
+import cairocffi as cairo
+cairo.enable_capi()
+
+from gi.repository import Gtk
+from gi.repository import Gdk
+
+
+class Viewport(Gtk.ScrolledWindow):
+    def __init__(self):
+        super(Viewport, self).__init__()
+
+        self.drawingArea = Gtk.DrawingArea()
+        self.drawingArea.set_app_paintable(True)
+        self.drawingArea.add_events(Gdk.EventMask.EXPOSURE_MASK |
+                                    Gdk.EventMask.SCROLL_MASK)
+        self.drawingArea.connect('draw', self.on_draw)
+        self.add_with_viewport(self.drawingArea)
+
+    def on_draw(self, widget, ctx):
+        extents = ctx.clip_extents()
+        ctx.scale (extents[2], extents[3]) # Normalizing the canvas
+
+        pat = cairo.LinearGradient (0.0, 0.0, 0.0, 1.0)
+        pat.add_color_stop_rgba (1, 0.7, 0, 0, 0.5) # First stop, 50% opacity
+        pat.add_color_stop_rgba (0, 0.9, 0.7, 0.2, 1) # Last stop, 100% opacity
+
+        ctx.rectangle (0, 0, 1, 1) # Rectangle(x0, y0, x1, y1)
+        ctx.set_source (pat)
+        ctx.fill ()
+
+        ctx.translate (0.1, 0.1) # Changing the current transformation matrix
+
+        ctx.move_to (0, 0)
+        ctx.arc (0.2, 0.1, 0.1, -math.pi/2, 0) # Arc(cx, cy, radius, start_angle, stop_angle)
+        ctx.line_to (0.5, 0.1) # Line to (x,y)
+        ctx.curve_to (0.5, 0.2, 0.5, 0.4, 0.2, 0.8) # Curve(x1, y1, x2, y2, x3, y3)
+        ctx.close_path ()
+
+        ctx.set_source_rgb (0.3, 0.2, 0.5) # Solid color
+        ctx.set_line_width (0.02)
+        ctx.stroke ()
+
+        return False
+
+
+def main(argv):
+    window = Gtk.Window()
+    window.connect('destroy', Gtk.main_quit)
+    vpt = Viewport()
+    window.add(vpt)
+    window.show_all()
+    Gtk.main()
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/cairocffi/test_capi.py
+++ b/cairocffi/test_capi.py
@@ -1,0 +1,88 @@
+# coding: utf8
+#
+# cairocffi.test_capi
+# ~~~~~~~~~~~~~~~~~
+# 
+# Tests for Pycairo C API compat
+# 
+# :copyright: Copyright 2013 by Simon Feltman
+# :license: BSD, see LICENSE for details.
+
+import gc
+import sys
+import unittest
+import ctypes
+
+import cairocffi as cairo
+from cairocffi import ffi
+from ctypes import pythonapi
+
+
+@unittest.skipUnless(sys.implementation.name == 'cpython',
+                     'Test can only run under cpython')
+class Test(unittest.TestCase):
+    def test_capsule(self):
+        # Pull the data back out of the capsule and test it.
+        from cairocffi import capi
+        data = pythonapi.PyCapsule_GetPointer(capi.CAPI, capi._capsule_name)
+        data_ptr = ffi.cast('void*', data)
+        self.assertEqual(data_ptr, capi._pycairo_api)
+
+    def test_class_ptr_stored_in_capi(self):
+        # Use ctypes to test the CAPI exposed by cffi
+        from cairocffi import capi
+        data = pythonapi.PyCapsule_GetPointer(capi.CAPI, capi._capsule_name)
+        data = ctypes.cast(data, ctypes.POINTER(ctypes.c_void_p))
+
+        self.assertEqual(data[0], id(cairo.Context))
+        self.assertEqual(data[2], id(cairo.FontFace))
+        self.assertEqual(data[3], id(cairo.ToyFontFace))
+        self.assertEqual(data[5], id(cairo.FontOptions))
+        self.assertEqual(data[7], id(cairo.Matrix))
+        self.assertEqual(data[11], id(cairo.Pattern))
+        self.assertEqual(data[12], id(cairo.SolidPattern))
+        self.assertEqual(data[13], id(cairo.SurfacePattern))
+        self.assertEqual(data[14], id(cairo.Gradient))
+        self.assertEqual(data[15], id(cairo.LinearGradient))
+        self.assertEqual(data[16], id(cairo.RadialGradient))
+        self.assertEqual(data[18], id(cairo.ScaledFont))
+        self.assertEqual(data[20], id(cairo.Surface))
+        self.assertEqual(data[21], id(cairo.ImageSurface))
+        self.assertEqual(data[22], id(cairo.PDFSurface))
+        self.assertEqual(data[23], id(cairo.PSSurface))
+        self.assertEqual(data[24], id(cairo.RecordingSurface))
+        self.assertEqual(data[25], id(cairo.SVGSurface))
+
+    def test_context_round_trip(self):
+        from cairocffi import capi
+        data = pythonapi.PyCapsule_GetPointer(capi.CAPI, capi._capsule_name)
+        data = ctypes.cast(data, ctypes.POINTER(ctypes.c_void_p))
+
+        Context_FromContext = ctypes.CFUNCTYPE(ctypes.py_object,
+                                               ctypes.c_void_p,
+                                               ctypes.c_void_p,
+                                               ctypes.c_void_p)(data[1])
+
+        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 32, 32)
+        cffi_ctx = cairo.Context(surface)
+        self.assertEqual(sys.getrefcount(cffi_ctx), 2)
+        self.assertEqual(cairo.cairo.cairo_get_reference_count(cffi_ctx._pointer), 1)
+
+        # call the C API through ctypes to get a new wrapper of the cairo context
+        ctx_addr = int(ffi.cast('uintptr_t', cffi_ctx._pointer))
+        ctypes_ctx = Context_FromContext(ctx_addr, None, None)
+        self.assertEqual(sys.getrefcount(cffi_ctx), 2)
+        self.assertEqual(sys.getrefcount(ctypes_ctx), 2)
+        self.assertEqual(cairo.cairo.cairo_get_reference_count(cffi_ctx._pointer), 2)
+        self.assertEqual(cairo.cairo.cairo_get_reference_count(ctypes_ctx._pointer), 2)
+        self.assertEqual(cffi_ctx._pointer, ctypes_ctx._pointer)
+
+        # verify context refcount decreases as things are deleted
+        del ctypes_ctx
+        gc.collect()
+        self.assertEqual(cairo.cairo.cairo_get_reference_count(cffi_ctx._pointer), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Hi,
This is an initial pass at having cairocffi support the Pycairo C API (limited to use with cpython). I've verified at least the context is working when used as a foreign type marshaled with PyGObject/GTK+ for drawing.
