### PR TITLE
Set zip_safe=False in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,5 @@ setup(
     ],
     packages=find_packages(),
     install_requires=['cffi>=0.6'],
+    zip_safe=False,
 )


### PR DESCRIPTION
You have to do this according to CFFI documentation: https://cffi.readthedocs.org/en/release-0.8/#distributing-modules-using-cffi
