### PR TITLE
Add Win32PrintingSurface

### DIFF
--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -99,7 +99,7 @@ def install_as_pycairo():
 # Implementation is in submodules, but public API is all here.
 
 from .surfaces import (Surface, ImageSurface, PDFSurface, PSSurface,
-                       SVGSurface, RecordingSurface)
+                       SVGSurface, RecordingSurface, Win32PrintingSurface)
 from .patterns import (Pattern, SolidPattern, SurfacePattern,
                        Gradient, LinearGradient, RadialGradient)
 from .fonts import FontFace, ToyFontFace, ScaledFont, FontOptions

--- a/cairocffi/constants.py
+++ b/cairocffi/constants.py
@@ -685,4 +685,10 @@ cairo_surface_t *cairo_svg_surface_create_for_stream(cairo_write_func_t write_fu
 void cairo_svg_surface_restrict_to_version(cairo_surface_t *surface, cairo_svg_version_t version);
 void cairo_svg_get_versions(const cairo_svg_version_t **versions, int *num_versions);
 const char *cairo_svg_version_to_string(cairo_svg_version_t version);
+cairo_surface_t *cairo_win32_surface_create(HDC hdc);
+cairo_surface_t *cairo_win32_surface_create_with_dib(cairo_format_t format, int width, int height);
+cairo_surface_t *cairo_win32_surface_create_with_ddb (HDC hdc, cairo_format_t format, int width, int height);
+cairo_surface_t *cairo_win32_printing_surface_create(HDC hdc);
+HDC cairo_win32_surface_get_dc(cairo_surface_t *surface);
+cairo_surface_t *cairo_win32_surface_get_image(cairo_surface_t *surface);
 """

--- a/cairocffi/surfaces.py
+++ b/cairocffi/surfaces.py
@@ -1274,9 +1274,15 @@ class RecordingSurface(Surface):
         return tuple(extents)
 
 
+class Win32PrintingSurface(Surface):
+    def __init__(self, hdc):
+        pointer = cairo.cairo_win32_printing_surface_create(ffi.cast('char*', hdc))
+        Surface.__init__(self, pointer)
+
 SURFACE_TYPE_TO_CLASS = {
     constants.SURFACE_TYPE_IMAGE: ImageSurface,
     constants.SURFACE_TYPE_PDF: PDFSurface,
     constants.SURFACE_TYPE_SVG: SVGSurface,
     constants.SURFACE_TYPE_RECORDING: RecordingSurface,
+    constants.SURFACE_TYPE_WIN32_PRINTING: Win32PrintingSurface
 }


### PR DESCRIPTION
I've added support for Win32PrintingSurface, tested in python 2.7 and 3.4. Documentation missing for now, but you just call Win32PrintingSurface with a hdc from win32gui.CreateDC, exactly like pycairo Win32PrintingSurface works.
