### PR TITLE
Use other ffi initialization in _encode_path

### DIFF
--- a/cairocffi/context.py
+++ b/cairocffi/context.py
@@ -57,7 +57,7 @@ def _encode_path(path_items):
             point.x = coordinates[i]
             point.y = coordinates[i + 1]
             position += 1
-    path = ffi.new('cairo_path_t *', (constants.STATUS_SUCCESS, data, length))
+    path = ffi.new('cairo_path_t *', {'status': constants.STATUS_SUCCESS, 'data': data, 'num_data': length})
     return path, data
 
 


### PR DESCRIPTION
With current initialization syntax, pypy2.4 sometimes fails
to init structure properly.

Fixes #46
