### PR TITLE
Keep cairo library loaded until all relevant objects are freed

### DIFF
--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -45,6 +45,13 @@ def dlopen(ffi, *names):
 
 cairo = dlopen(ffi, 'cairo', 'cairo-2')
 
+class _keepref(object):
+    """Function wrapper that keeps a reference to another object."""
+    def __init__(self, ref, func):
+        self.ref = ref
+        self.func = func
+    def __call__(self, *args, **kwargs):
+        self.func(*args, **kwargs)
 
 class CairoError(Exception):
     """Raised when cairo returns an error status."""

--- a/cairocffi/context.py
+++ b/cairocffi/context.py
@@ -10,7 +10,7 @@
 
 """
 
-from . import ffi, cairo, _check_status, constants
+from . import ffi, cairo, _check_status, constants, _keepref
 from .matrix import Matrix
 from .patterns import Pattern
 from .surfaces import Surface
@@ -101,7 +101,7 @@ class Context(object):
         self._init_pointer(cairo.cairo_create(target._pointer))
 
     def _init_pointer(self, pointer):
-        self._pointer = ffi.gc(pointer, cairo.cairo_destroy)
+        self._pointer = ffi.gc(pointer, _keepref(cairo, cairo.cairo_destroy))
         self._check_status()
 
     def _check_status(self):

--- a/cairocffi/fonts.py
+++ b/cairocffi/fonts.py
@@ -10,7 +10,7 @@
 
 """
 
-from . import ffi, cairo, _check_status, constants
+from . import ffi, cairo, _check_status, constants, _keepref
 from .matrix import Matrix
 from .compat import xrange
 
@@ -31,7 +31,8 @@ class FontFace(object):
 
     """
     def __init__(self, pointer):
-        self._pointer = ffi.gc(pointer, cairo.cairo_font_face_destroy)
+        self._pointer = ffi.gc(
+            pointer, _keepref(cairo, cairo.cairo_font_face_destroy))
         self._check_status()
 
     def _check_status(self):
@@ -137,7 +138,8 @@ class ScaledFont(object):
             ctm._pointer, options._pointer))
 
     def _init_pointer(self, pointer):
-        self._pointer = ffi.gc(pointer, cairo.cairo_scaled_font_destroy)
+        self._pointer = ffi.gc(
+            pointer, _keepref(cairo, cairo.cairo_scaled_font_destroy))
         self._check_status()
 
     def _check_status(self):
@@ -347,9 +349,10 @@ class ScaledFont(object):
         status = cairo.cairo_scaled_font_text_to_glyphs(
             self._pointer, x, y, _encode_string(text), -1,
             glyphs, num_glyphs, clusters, num_clusters, cluster_flags)
-        glyphs = ffi.gc(glyphs[0], cairo.cairo_glyph_free)
+        glyphs = ffi.gc(glyphs[0], _keepref(cairo, cairo.cairo_glyph_free))
         if with_clusters:
-            clusters = ffi.gc(clusters[0], cairo.cairo_text_cluster_free)
+            clusters = ffi.gc(
+                clusters[0], _keepref(cairo, cairo.cairo_text_cluster_free))
         _check_status(status)
         glyphs = [
             (glyph.index, glyph.x, glyph.y)
@@ -393,7 +396,8 @@ class FontOptions(object):
             getattr(self, 'set_' + name)(value)
 
     def _init_pointer(self, pointer):
-        self._pointer = ffi.gc(pointer, cairo.cairo_font_options_destroy)
+        self._pointer = ffi.gc(
+            pointer, _keepref(cairo, cairo.cairo_font_options_destroy))
         self._check_status()
 
     def _check_status(self):

--- a/cairocffi/patterns.py
+++ b/cairocffi/patterns.py
@@ -10,7 +10,7 @@
 
 """
 
-from . import ffi, cairo, _check_status, constants
+from . import ffi, cairo, _check_status, constants, _keepref
 from .matrix import Matrix
 from .surfaces import Surface
 from .compat import xrange
@@ -34,7 +34,8 @@ class Pattern(object):
 
     """
     def __init__(self, pointer):
-        self._pointer = ffi.gc(pointer, cairo.cairo_pattern_destroy)
+        self._pointer = ffi.gc(
+            pointer, _keepref(cairo, cairo.cairo_pattern_destroy))
         self._check_status()
 
     def _check_status(self):

--- a/cairocffi/surfaces.py
+++ b/cairocffi/surfaces.py
@@ -15,7 +15,7 @@ import sys
 import ctypes
 import weakref
 
-from . import ffi, cairo, _check_status, constants
+from . import ffi, cairo, _check_status, constants, _keepref
 from .fonts import FontOptions, _encode_string
 
 
@@ -128,7 +128,8 @@ class Surface(object):
 
     """
     def __init__(self, pointer, target_keep_alive=None):
-        self._pointer = ffi.gc(pointer, cairo.cairo_surface_destroy)
+        self._pointer = ffi.gc(
+            pointer, _keepref(cairo, cairo.cairo_surface_destroy))
         self._check_status()
         if target_keep_alive not in (None, ffi.NULL):
             keep_alive = KeepAlive(target_keep_alive)


### PR DESCRIPTION
The CFFI documentation says that the "library" object returned by `ffi.dlopen()` is closed when it goes out of scope, and notes "Make sure you keep the library object around as long as needed."

When a symbol is retrieved from a library, the returned object does not keep a reference to the library it was loaded from.  It is possible for the library to be closed while there are still some of these objects around; using them subsequently can cause undefined behaviour.

When the Python interpreter is shutting down, the lack of reference from the library symbol object to the library may cause it to destroy objects in the wrong order; in particular, the cairo module may be wiped (removing the only reference to the cairo library object) while cdata objects returned by `ffi.gc()` with a destructor implemented in the cairo library still exist.

This commit keeps a reference to the cairo library object alongside the destructor, ensuring that the library will not be unloaded until all the destructors have been called.  This should fix the segfault on exit problem described in github issue #73.