### PR TITLE
Drop tests with PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
-  - "pypy"
+  - "3.5"
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ before_install:
 install:
   - "pip install xcffib"
   - "pip install ."
+  - "python cairocffi/ffi_build.py"
 script: "py.test"
 sudo: false

--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -16,11 +16,7 @@ import ctypes.util
 from . import constants
 from .compat import FileNotFoundError
 
-try:
-    from ._ffi import ffi
-except ImportError:
-    # PyPy < 2.6 compatibility
-    from .ffi_build import ffi
+from ._ffi import ffi
 
 VERSION = '0.7.2'
 # pycairo compat:

--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -15,7 +15,6 @@ import ctypes.util
 
 from . import constants
 from .compat import FileNotFoundError
-
 from ._ffi import ffi
 
 VERSION = '0.7.2'

--- a/cairocffi/ffi_build.py
+++ b/cairocffi/ffi_build.py
@@ -24,9 +24,7 @@ from cairocffi import constants
 
 # Primary cffi definitions
 ffi = FFI()
-if hasattr(ffi, 'set_source'):
-    # PyPy < 2.6 compatibility
-    ffi.set_source('cairocffi._ffi', None)
+ffi.set_source('cairocffi._ffi', None)
 ffi.cdef(constants._CAIRO_HEADERS)
 
 # include xcffib cffi definitions for cairo xcb support
@@ -39,9 +37,7 @@ except ImportError:
 
 # gdk pixbuf cffi definitions
 ffi_pixbuf = FFI()
-if hasattr(ffi_pixbuf, 'set_source'):
-    # PyPy < 2.6 compatibility
-    ffi_pixbuf.set_source('cairocffi._ffi_pixbuf', None)
+ffi_pixbuf.set_source('cairocffi._ffi_pixbuf', None)
 ffi_pixbuf.include(ffi)
 ffi_pixbuf.cdef('''
     typedef unsigned long   gsize;

--- a/cairocffi/ffi_build.py
+++ b/cairocffi/ffi_build.py
@@ -19,7 +19,7 @@ this_file = os.path.abspath(__file__)
 this_dir = os.path.split(this_file)[0]
 sys.path.append(this_dir)
 
-from cairocffi import constants
+import constants
 
 
 # Primary cffi definitions

--- a/cairocffi/ffi_build.py
+++ b/cairocffi/ffi_build.py
@@ -16,7 +16,7 @@ from cffi import FFI
 
 # Path hack to import constants when this file is exec'd by setuptools
 this_file = os.path.abspath(__file__)
-this_dir = os.path.split(this_file)[0]
+this_dir = os.path.dirname(this_file)
 sys.path.append(this_dir)
 
 import constants

--- a/cairocffi/pixbuf.py
+++ b/cairocffi/pixbuf.py
@@ -16,13 +16,9 @@ from functools import partial
 from array import array
 
 from . import dlopen, ImageSurface, Context, constants
+from ._ffi_pixbuf import ffi
 from .compat import xrange
 
-try:
-    from ._ffi_pixbuf import ffi
-except ImportError:
-    # PyPy < 2.6 compatibility
-    from .ffi_build import ffi_pixbuf as ffi
 
 __all__ = ['decode_to_image_surface']
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from setuptools import setup, find_packages
 from os import path
 import re
 import io
-import sys
 
 
 VERSION = re.search(
@@ -18,20 +17,6 @@ LONG_DESCRIPTION = io.open(
     encoding='utf-8',
 ).read()
 
-if '_cffi_backend' in sys.builtin_module_names:
-    import _cffi_backend
-    requires_cffi = "cffi==" + _cffi_backend.__version__
-else:
-    requires_cffi = "cffi>=1.1.0"
-
-# PyPy < 2.6 compatibility
-if requires_cffi.startswith("cffi==0."):
-    cffi_args = dict()
-else:
-    cffi_args = dict(cffi_modules=[
-        'cairocffi/ffi_build.py:ffi',
-        'cairocffi/ffi_build.py:ffi_pixbuf'
-    ])
 
 try:
     import cffi
@@ -59,8 +44,11 @@ setup(
         'Topic :: Multimedia :: Graphics',
     ],
     packages=find_packages(),
-    install_requires=[requires_cffi],
-    setup_requires=[requires_cffi],
+    install_requires=['cffi>=1.1.0'],
+    setup_requires=['cffi>=1.1.0'],
+    cffi_modules=[
+        'cairocffi/ffi_build.py:ffi',
+        'cairocffi/ffi_build.py:ffi_pixbuf'
+    ],
     extras_require={'xcb': ['xcffib>=0.3.2']},
-    **cffi_args
 )

--- a/setup.py
+++ b/setup.py
@@ -17,15 +17,6 @@ LONG_DESCRIPTION = io.open(
     encoding='utf-8',
 ).read()
 
-
-try:
-    import cffi
-    if cffi.__version__.startswith('0.'):
-        # https://github.com/SimonSapin/cairocffi/issues/64
-        cffi_args = dict()
-except ImportError:
-    pass
-
 setup(
     name='cairocffi',
     version=VERSION,


### PR DESCRIPTION
Commit 82a2434 fixes tests for PyPy but introduces a bug often reported in WeasyPrint (at least Kozea/WeasyPrint#281, Kozea/WeasyPrint#302, Kozea/WeasyPrint#348).

Unfortunately, Travis only provides PyPy 2.5 (see travis-ci/travis-ci#4756) with CFFI 0.9. We can re-add `pypy` in `.travis.yml` when it's fixed. Until then, it's probably better to have a clean `setup.py`.