### PR TITLE
Add width and height options to pixbuf.decode_to_image_surface

### DIFF
--- a/cairocffi/ffi_build.py
+++ b/cairocffi/ffi_build.py
@@ -68,6 +68,8 @@ ffi_pixbuf.cdef('''
     gboolean          gdk_pixbuf_loader_write        (
         GdkPixbufLoader *loader, const guchar *buf, gsize count,
         GError **error);
+    void              gdk_pixbuf_loader_set_size (
+        GdkPixbufLoader *loader, int width, int height);
     gboolean          gdk_pixbuf_loader_close        (
         GdkPixbufLoader *loader, GError **error);
 

--- a/cairocffi/pixbuf.py
+++ b/cairocffi/pixbuf.py
@@ -74,6 +74,8 @@ def decode_to_pixbuf(image_data, width=None, height=None):
     The file format is detected automatically.
 
     :param image_data: A byte string
+    :param width: Integer width in pixels or None
+    :param height: Integer height in pixels or None
     :returns:
         A tuple of a new :class:`PixBuf` object
         and the name of the detected image format.
@@ -108,6 +110,8 @@ def decode_to_image_surface(image_data, width=None, height=None):
     The file format is detected automatically.
 
     :param image_data: A byte string
+    :param width: Integer width in pixels or None
+    :param height: Integer height in pixels or None
     :returns:
         A tuple of a new :class:`~cairocffi.ImageSurface` object
         and the name of the detected image format.

--- a/cairocffi/pixbuf.py
+++ b/cairocffi/pixbuf.py
@@ -69,7 +69,7 @@ class Pixbuf(object):
         return partial(function, self._pointer)
 
 
-def decode_to_pixbuf(image_data):
+def decode_to_pixbuf(image_data, width=None, height=None):
     """Decode an image from memory with GDK-PixBuf.
     The file format is detected automatically.
 
@@ -85,6 +85,8 @@ def decode_to_pixbuf(image_data):
     loader = ffi.gc(
         gdk_pixbuf.gdk_pixbuf_loader_new(), gobject.g_object_unref)
     error = ffi.new('GError **')
+    if width and height:
+        gdk_pixbuf.gdk_pixbuf_loader_set_size(loader, width, height)
     handle_g_error(error, gdk_pixbuf.gdk_pixbuf_loader_write(
         loader, ffi.new('guchar[]', image_data), len(image_data), error))
     handle_g_error(error, gdk_pixbuf.gdk_pixbuf_loader_close(loader, error))
@@ -101,7 +103,7 @@ def decode_to_pixbuf(image_data):
     return Pixbuf(pixbuf), format_name
 
 
-def decode_to_image_surface(image_data):
+def decode_to_image_surface(image_data, width=None, height=None):
     """Decode an image from memory into a cairo surface.
     The file format is detected automatically.
 
@@ -114,7 +116,7 @@ def decode_to_image_surface(image_data):
         or in an unsupported format.
 
     """
-    pixbuf, format_name = decode_to_pixbuf(image_data)
+    pixbuf, format_name = decode_to_pixbuf(image_data, width, height)
     surface = (
         pixbuf_to_cairo_gdk(pixbuf) if gdk is not None
         else pixbuf_to_cairo_slices(pixbuf) if not pixbuf.get_has_alpha()


### PR DESCRIPTION
This patch lets you optionally give a width and height to
`pixbuf.decode_to_image_surface`. This is useful for loading scalable
graphics.

The graphic shown below is a test using this patch. A small svg image
was loaded and scaled to be 10x its size. The patched version can do this by specifying this new width and height to `pixbuf.decode_to_image_surface`, while the orignal version needs to be scaled using cairo operations.
![out2](https://cloud.githubusercontent.com/assets/8061555/25680005/5a453eaa-301d-11e7-85d2-f23e3ac70bac.png)
