### PR TITLE
Add cairo library name from PyGObject for Windows

### DIFF
--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -38,7 +38,7 @@ def dlopen(ffi, *names):
     raise OSError("dlopen() failed to load a library: %s" % ' / '.join(names))
 
 
-cairo = dlopen(ffi, 'cairo', 'cairo-2')
+cairo = dlopen(ffi, 'cairo', 'cairo-2', 'cairo-gobject-2')
 
 
 class _keepref(object):


### PR DESCRIPTION
[PyGObject for Windows](https://sourceforge.net/projects/pygobjectwin32/) named its cairo library as `libcairo-gobject-2.dll`, which is installed when GTK+ option is checked.
This commit might help cairocffi getting cairo library linked from PyGObject for Windows.