### PR TITLE
Fix test compatibility with Cairo 1.15.12

### DIFF
--- a/cairocffi/test_cairo.py
+++ b/cairocffi/test_cairo.py
@@ -292,7 +292,8 @@ def test_pdf_surface():
         pdf_bytes = file_obj.getvalue()
         assert pdf_bytes.startswith(b'%PDF')
         assert b'/MediaBox [ 0 0 123 432 ]' in pdf_bytes
-        assert pdf_bytes.count(b'/Type /Page\n') == 1
+        assert pdf_bytes.count(b'/Type /Pages') == 1
+        assert pdf_bytes.count(b'/Type /Page') == 2
 
     file_obj = io.BytesIO()
     surface = PDFSurface(file_obj, 1, 1)
@@ -306,7 +307,8 @@ def test_pdf_surface():
     assert b'/MediaBox [ 0 0 1 1 ]' not in pdf_bytes
     assert b'/MediaBox [ 0 0 12 100 ]' in pdf_bytes
     assert b'/MediaBox [ 0 0 42 700 ]' in pdf_bytes
-    assert pdf_bytes.count(b'/Type /Page\n') == 2
+    assert pdf_bytes.count(b'/Type /Pages') == 1
+    assert pdf_bytes.count(b'/Type /Page') == 3
 
 
 def test_svg_surface():


### PR DESCRIPTION
Cairo 1.15.12 generates PDFs with page numbers in comments. This was generated by the first test case in `test_pdf_surface`:
```
2 0 obj
<< /Type /Page % 1
   /Parent 1 0 R
   /MediaBox [ 0 0 123 432 ]
   /Contents 4 0 R
   /Group <<
      /Type /Group
      /S /Transparency
      /I true
      /CS /DeviceRGB
   >>
   /Resources 3 0 R
>>
endobj
```
See the attached PDF for the second test case from `test_pdf_surface`:
[test_pdf_surface-2.pdf](https://github.com/Kozea/cairocffi/files/2066700/test_pdf_surface-2.pdf)
