### PR TITLE
Update pixbuf to find glib-2.0.so..

### DIFF
--- a/cairocffi/pixbuf.py
+++ b/cairocffi/pixbuf.py
@@ -21,7 +21,7 @@ __all__ = ['decode_to_image_surface']
 
 gdk_pixbuf = dlopen(ffi, 'gdk_pixbuf-2.0', 'gdk_pixbuf-2.0-0')
 gobject = dlopen(ffi, 'gobject-2.0', 'gobject-2.0-0')
-glib = dlopen(ffi, 'glib-2.0', 'glib-2.0-0')
+glib = dlopen(ffi, 'glib-2.0', 'glib-2.0-0', 'glib-2.0.so')
 try:
     gdk = dlopen(ffi, 'gdk-3', 'gdk-x11-2.0', 'gdk-win32-2.0-0')
 except OSError:


### PR DESCRIPTION
when installed through conda. If `.so` is missing, only a directory named `glib-2.0` might be found.
```
$ ll ~/anaconda-envs/dev/lib/ | grep glib
drwxrwxr-x  3 base base     4096 Mar 18 09:18 glib-2.0
lrwxrwxrwx  1 base base       23 Apr  4 10:04 libglib-2.0.so -> libglib-2.0.so.0.5800.3
lrwxrwxrwx  1 base base       23 Apr  4 10:04 libglib-2.0.so.0 -> libglib-2.0.so.0.5800.3
-rwxrwxr-x  1 base base  1354816 Apr  4 10:04 libglib-2.0.so.0.5800.3
```