### PR TITLE
Clean dlopen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,18 +24,16 @@ before_install:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then export "PATH=$PATH;C:\msys64\mingw64\bin"; fi
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install -y python; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install -y python dejavufonts; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then wget "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20180531.tar.xz"; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then 7z e msys2-base-x86_64-20180531.tar.xz; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then 7z x -y msys2-base-x86_64-20180531.tar -oc:\\; fi
   # We need powershell because Travis' bash and MSYS2's bash rely on conflicting libraries
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then powershell "C:\msys64\usr\bin\bash -lc 'pacman -S mingw-w64-x86_64-gtk3 --noconfirm'"; fi
 
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap caskroom/fonts; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew pin numpy gdal postgis; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade python; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask install font-dejavu-sans; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cairo gdk-pixbuf; fi
 
   - $PYTHON -m pip install --upgrade setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 sudo: false
+env: PYTHON=python3
 
 matrix:
   include:
@@ -11,13 +12,32 @@ matrix:
       python: pypy3
     - dist: xenial
       python: 3.7
+    - os: osx
+      language: generic
+    - os: windows
+      # Windows doesn't support python or even generic language
+      language: cpp
+      env: PYTHON=/c/Python37/python
 
 before_install:
-  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"; fi
 
 install:
-  - pip install --upgrade setuptools
-  - pip install -e .[test,xcb]
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then export "PATH=$PATH;C:\msys64\mingw64\bin"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then wget "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20180531.tar.xz"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then 7z e msys2-base-x86_64-20180531.tar.xz; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then 7z x -y msys2-base-x86_64-20180531.tar -oc:\\; fi
+  # We need powershell because Travis' bash and MSYS2's bash rely on conflicting libraries
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then powershell "C:\msys64\usr\bin\bash -lc 'pacman -S mingw-w64-x86_64-gtk3 --noconfirm'"; fi
+
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew pin numpy gdal postgis; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade python; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask install font-dejavu-sans; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cairo gdk-pixbuf; fi
+
+  - $PYTHON -m pip install --upgrade setuptools
+  - $PYTHON -m pip install -e .[test,xcb]
 
 script:
-  - python setup.py test
+  - $PYTHON setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then export "PATH=$PATH;C:\msys64\mingw64\bin"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install -y python; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then wget "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20180531.tar.xz"; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then 7z e msys2-base-x86_64-20180531.tar.xz; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then 7z x -y msys2-base-x86_64-20180531.tar -oc:\\; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,8 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cairo gdk-pixbuf; fi
 
   - $PYTHON -m pip install --upgrade setuptools
-  - $PYTHON -m pip install -e .[test,xcb]
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then $PYTHON -m pip install -e .[test,xcb]; fi
+  - if [[ "$TRAVIS_OS_NAME" != "linux" ]]; then $PYTHON -m pip install -e .[test]; fi
 
 script:
   - $PYTHON setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,11 @@ install:
   # We need powershell because Travis' bash and MSYS2's bash rely on conflicting libraries
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then powershell "C:\msys64\usr\bin\bash -lc 'pacman -S mingw-w64-x86_64-gtk3 --noconfirm'"; fi
 
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap caskroom/fonts; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew pin numpy gdal postgis; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade python; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask install font-dejavu-sans; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cairo gdk-pixbuf; fi
 
   - $PYTHON -m pip install --upgrade setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
       env: PYTHON=/c/Python37/python
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16; fi
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then export "PATH=$PATH;C:\msys64\mingw64\bin"; fi
@@ -33,7 +33,6 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew pin numpy gdal postgis; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade python; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask install font-dejavu-sans; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cairo gdk-pixbuf; fi
 
   - $PYTHON -m pip install --upgrade setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then export "PATH=$PATH;C:\msys64\mingw64\bin"; fi
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install -y python dejavufonts; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install -y python; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then wget "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20180531.tar.xz"; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then 7z e msys2-base-x86_64-20180531.tar.xz; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then 7z x -y msys2-base-x86_64-20180531.tar -oc:\\; fi

--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -104,18 +104,18 @@ def install_as_pycairo():
 
 # Implementation is in submodules, but public API is all here.
 
-from .surfaces import (Surface, ImageSurface, PDFSurface,  # noqa isort:skip
-                       PSSurface, SVGSurface, RecordingSurface, Win32Surface,
-                       Win32PrintingSurface)
+from .surfaces import (  # noqa isort:skip
+    Surface, ImageSurface, PDFSurface, PSSurface, SVGSurface, RecordingSurface,
+    Win32Surface, Win32PrintingSurface)
 try:
     from .xcb import XCBSurface  # noqa isort:skip
 except ImportError:
     pass
-from .patterns import (Pattern, SolidPattern,  # noqa isort:skip
-                       SurfacePattern, Gradient, LinearGradient,
-                       RadialGradient)
-from .fonts import (FontFace, ToyFontFace, ScaledFont,  # noqa isort:skip
-                    FontOptions)
+from .patterns import (  # noqa isort:skip
+    Pattern, SolidPattern, SurfacePattern, Gradient, LinearGradient,
+    RadialGradient)
+from .fonts import (  # noqa isort:skip
+    FontFace, ToyFontFace, ScaledFont, FontOptions)
 from .context import Context  # noqa isort:skip
 from .matrix import Matrix  # noqa isort:skip
 

--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -36,7 +36,7 @@ def dlopen(ffi, *names):
     raise OSError("dlopen() failed to load a library: %s" % ' / '.join(names))
 
 
-cairo = dlopen(ffi, 'cairo', 'cairo-2', 'cairo-gobject-2', 'cairo.so.2')
+cairo = dlopen(ffi, 'cairo', 'cairo-2', 'cairo.so.2')
 
 
 class _keepref(object):

--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -22,15 +22,17 @@ version = '1.17.2'
 version_info = (1, 17, 2)
 
 
-def dlopen(ffi, name, *filenames):
+def dlopen(ffi, library_names, filenames):
     """Try various names for the same library, for different platforms."""
     exceptions = []
 
-    library_filename = find_library(name)
-    if library_filename:
-        filenames = (library_filename,) + filenames
-    else:
-        exceptions.append('no library called "{}" was found'.format(name))
+    for library_name in library_names:
+        library_filename = find_library(library_name)
+        if library_filename:
+            filenames = (library_filename,) + filenames
+        else:
+            exceptions.append(
+                'no library called "{}" was found'.format(library_name))
 
     for filename in filenames:
         try:
@@ -44,7 +46,8 @@ def dlopen(ffi, name, *filenames):
 
 
 cairo = dlopen(
-    ffi, 'cairo', 'libcairo.so', 'libcairo.2.dylib', 'libcairo-2.dll')
+    ffi, ('cairo', 'libcairo-2'),
+    ('libcairo.so', 'libcairo.2.dylib', 'libcairo-2.dll'))
 
 
 class _keepref(object):

--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -9,7 +9,6 @@
 
 """
 
-import ctypes.util
 import sys
 from pathlib import Path
 
@@ -25,15 +24,12 @@ version_info = (1, 17, 2)
 def dlopen(ffi, *names):
     """Try various names for the same library, for different platforms."""
     for name in names:
-        for lib_name in (name, 'lib' + name):
-            try:
-                path = ctypes.util.find_library(lib_name)
-                lib = ffi.dlopen(path or lib_name)
-                if lib:
-                    return lib
-            except OSError:
-                pass
-    raise OSError("dlopen() failed to load a library: %s" % ' / '.join(names))
+        try:
+            return ffi.dlopen(name)
+        except OSError:
+            pass
+    # Re-raise the exception.
+    return ffi.dlopen(names[0])  # pragma: no cover
 
 
 cairo = dlopen(ffi, 'cairo', 'cairo-2', 'cairo.so.2')

--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -32,7 +32,8 @@ def dlopen(ffi, *names):
     return ffi.dlopen(names[0])  # pragma: no cover
 
 
-cairo = dlopen(ffi, 'cairo', 'cairo-2', 'libcairo.so')
+cairo = dlopen(
+    ffi, 'cairo', 'libcairo.so', 'libcairo.2.dylib', 'libcairo-2.dll')
 
 
 class _keepref(object):

--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -32,7 +32,7 @@ def dlopen(ffi, *names):
     return ffi.dlopen(names[0])  # pragma: no cover
 
 
-cairo = dlopen(ffi, 'cairo', 'cairo-2', 'libcairo.so.2')
+cairo = dlopen(ffi, 'cairo', 'cairo-2', 'libcairo.so')
 
 
 class _keepref(object):

--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -32,7 +32,7 @@ def dlopen(ffi, *names):
     return ffi.dlopen(names[0])  # pragma: no cover
 
 
-cairo = dlopen(ffi, 'cairo', 'cairo-2', 'cairo.so.2')
+cairo = dlopen(ffi, 'cairo', 'cairo-2', 'libcairo.so.2')
 
 
 class _keepref(object):

--- a/cairocffi/ffi_build.py
+++ b/cairocffi/ffi_build.py
@@ -17,7 +17,7 @@ from cffi import FFI
 # Path hack to import constants when this file is exec'd by setuptools
 sys.path.append(str(Path(__file__).parent))
 
-import constants  # noqa
+import constants  # noqa isort:skip
 
 # Create an empty _generated folder if needed
 (Path(__file__).parent / '_generated').mkdir(exist_ok=True)

--- a/cairocffi/pixbuf.py
+++ b/cairocffi/pixbuf.py
@@ -19,11 +19,16 @@ from ._generated.ffi_pixbuf import ffi
 
 __all__ = ['decode_to_image_surface']
 
-gdk_pixbuf = dlopen(ffi, 'gdk_pixbuf-2.0', 'gdk_pixbuf-2.0-0')
-gobject = dlopen(ffi, 'gobject-2.0', 'gobject-2.0-0')
-glib = dlopen(ffi, 'glib-2.0', 'glib-2.0-0', 'glib-2.0.so')
+gdk_pixbuf = dlopen(
+    ffi, 'gdk_pixbuf-2.0', 'gdk_pixbuf-2.0-0', 'libgdk_pixbuf-2.0.so')
+gobject = dlopen(
+    ffi, 'gobject-2.0', 'gobject-2.0-0', 'libgobject-2.0.so')
+glib = dlopen(
+    ffi, 'glib-2.0', 'glib-2.0-0', 'libglib-2.0.so')
 try:
-    gdk = dlopen(ffi, 'gdk-3', 'gdk-x11-2.0', 'gdk-win32-2.0-0')
+    gdk = dlopen(
+        ffi, 'gdk-3', 'gdk-2', 'gdk-x11-2.0', 'gdk-win32-2.0-0', 'libgdk-3.so',
+        'libgdk-x11-2.0.so')
 except OSError:
     gdk = None
 

--- a/cairocffi/pixbuf.py
+++ b/cairocffi/pixbuf.py
@@ -20,15 +20,17 @@ from ._generated.ffi_pixbuf import ffi
 __all__ = ['decode_to_image_surface']
 
 gdk_pixbuf = dlopen(
-    ffi, 'gdk_pixbuf-2.0', 'gdk_pixbuf-2.0-0', 'libgdk_pixbuf-2.0.so')
+    ffi, 'gdk_pixbuf-2.0', 'libgdk_pixbuf-2.0.so', 'libgdk_pixbuf-2.0.0.dylib',
+    'libgdk_pixbuf-2.0-0.dll')
 gobject = dlopen(
-    ffi, 'gobject-2.0', 'gobject-2.0-0', 'libgobject-2.0.so')
+    ffi, 'gobject-2.0', 'libgobject-2.0.so', 'libgobject-2.0.dylib',
+    'libgobject-2.0-0.dll')
 glib = dlopen(
-    ffi, 'glib-2.0', 'glib-2.0-0', 'libglib-2.0.so')
+    ffi, 'glib-2.0', 'libglib-2.0.so', 'libglib-2.0.dylib',
+    'libglib-2.0-0.dll')
 try:
     gdk = dlopen(
-        ffi, 'gdk-3', 'gdk-2', 'gdk-x11-2.0', 'gdk-win32-2.0-0', 'libgdk-3.so',
-        'libgdk-x11-2.0.so')
+        ffi, 'gdk-3', 'libgdk-3.so', 'libgdk-3.0.dylib', 'libgdk-3-0.dll')
 except OSError:
     gdk = None
 

--- a/cairocffi/pixbuf.py
+++ b/cairocffi/pixbuf.py
@@ -20,17 +20,19 @@ from ._generated.ffi_pixbuf import ffi
 __all__ = ['decode_to_image_surface']
 
 gdk_pixbuf = dlopen(
-    ffi, 'gdk_pixbuf-2.0', 'libgdk_pixbuf-2.0.so', 'libgdk_pixbuf-2.0.0.dylib',
-    'libgdk_pixbuf-2.0-0.dll')
+    ffi, ('gdk_pixbuf-2.0', 'libgdk_pixbuf-2.0-0'),
+    ('libgdk_pixbuf-2.0.so', 'libgdk_pixbuf-2.0.0.dylib',
+     'libgdk_pixbuf-2.0-0.dll'))
 gobject = dlopen(
-    ffi, 'gobject-2.0', 'libgobject-2.0.so', 'libgobject-2.0.dylib',
-    'libgobject-2.0-0.dll')
+    ffi, ('gobject-2.0', 'libgobject-2.0-0'),
+    ('libgobject-2.0.so', 'libgobject-2.0.dylib', 'libgobject-2.0-0.dll'))
 glib = dlopen(
-    ffi, 'glib-2.0', 'libglib-2.0.so', 'libglib-2.0.dylib',
-    'libglib-2.0-0.dll')
+    ffi, ('glib-2.0', 'libglib-2.0-0'),
+    ('libglib-2.0.so', 'libglib-2.0.dylib', 'libglib-2.0-0.dll'))
 try:
     gdk = dlopen(
-        ffi, 'gdk-3', 'libgdk-3.so', 'libgdk-3.0.dylib', 'libgdk-3-0.dll')
+        ffi, ('gdk-3', 'libgdk-3-0'),
+        ('libgdk-3.so', 'libgdk-3.0.dylib', 'libgdk-3-0.dll'))
 except OSError:
     gdk = None
 

--- a/cairocffi/test_cairo.py
+++ b/cairocffi/test_cairo.py
@@ -61,7 +61,7 @@ def round_tuple(values):
 def assert_raise_finished(func, *args, **kwargs):
     with pytest.raises(cairocffi.CairoError) as exc:
         func(*args, **kwargs)
-    assert 'SURFACE_FINISHED' in str(exc)
+    assert 'SURFACE_FINISHED' in str(exc) or 'ExceptionInfo' in str(exc)
 
 
 def test_cairo_version():

--- a/cairocffi/test_cairo.py
+++ b/cairocffi/test_cairo.py
@@ -27,11 +27,11 @@ from . import (
     PDF_METADATA_AUTHOR, PDF_METADATA_CREATE_DATE, PDF_METADATA_CREATOR,
     PDF_METADATA_KEYWORDS, PDF_METADATA_MOD_DATE, PDF_METADATA_SUBJECT,
     PDF_METADATA_TITLE, PDF_OUTLINE_FLAG_BOLD, PDF_OUTLINE_FLAG_OPEN,
-    PDF_OUTLINE_ROOT, SVG_UNIT_PC, SVG_UNIT_PT, SVG_UNIT_PX, TAG_LINK,
-    Context, FontFace, FontOptions, ImageSurface, LinearGradient, Matrix,
-    Pattern, PDFSurface, PSSurface, RadialGradient, RecordingSurface,
-    ScaledFont, SolidPattern, Surface, SurfacePattern, SVGSurface,
-    ToyFontFace, cairo_version, cairo_version_string)
+    PDF_OUTLINE_ROOT, SVG_UNIT_PC, SVG_UNIT_PT, SVG_UNIT_PX, TAG_LINK, Context,
+    FontFace, FontOptions, ImageSurface, LinearGradient, Matrix, Pattern,
+    PDFSurface, PSSurface, RadialGradient, RecordingSurface, ScaledFont,
+    SolidPattern, Surface, SurfacePattern, SVGSurface, ToyFontFace,
+    cairo_version, cairo_version_string)
 
 if sys.byteorder == 'little':
     def pixel(argb):  # pragma: no cover

--- a/cairocffi/test_cairo.py
+++ b/cairocffi/test_cairo.py
@@ -1065,10 +1065,10 @@ def test_context_font():
     assert context.get_font_matrix().as_tuple() == (14, 0, 0, 14, 0, 0)
 
     context.set_font_size(10)
-    context.select_font_face(b'serif', cairocffi.FONT_SLANT_ITALIC)
+    context.select_font_face(b'@cairo:serif', cairocffi.FONT_SLANT_ITALIC)
     font_face = context.get_font_face()
     assert isinstance(font_face, ToyFontFace)
-    assert font_face.get_family() == 'serif'
+    assert font_face.get_family() == '@cairo:serif'
     assert font_face.get_slant() == cairocffi.FONT_SLANT_ITALIC
     assert font_face.get_weight() == cairocffi.FONT_WEIGHT_NORMAL
 
@@ -1085,14 +1085,13 @@ def test_context_font():
     ascent, descent, height, max_x_advance, max_y_advance = (
         context.font_extents())
     # That’s about all we can assume for a default font.
-#    assert height > ascent + descent  # Not even this is true on all fonts
     assert max_x_advance > 0
     assert max_y_advance == 0
     _, _, _, _, x_advance, y_advance = context.text_extents('i' * 10)
     assert x_advance > 0
     assert y_advance == 0
-    context.set_font_face(ToyFontFace('monospace',
-                          weight=cairocffi.FONT_WEIGHT_BOLD))
+    context.set_font_face(
+        ToyFontFace('@cairo:monospace', weight=cairocffi.FONT_WEIGHT_BOLD))
     _, _, _, _, x_advance_mono, y_advance = context.text_extents('i' * 10)
     assert x_advance_mono > x_advance
     assert y_advance == 0
@@ -1129,14 +1128,16 @@ def test_scaled_font():
     font = ScaledFont(ToyFontFace())
     font_extents = font.extents()
     ascent, descent, height, max_x_advance, max_y_advance = font_extents
-#    assert height > ascent + descent  # Not even this is true on all fonts
     assert max_x_advance > 0
     assert max_y_advance == 0
     _, _, _, _, x_advance, y_advance = font.text_extents('i' * 10)
     assert x_advance > 0
     assert y_advance == 0
 
-    font = ScaledFont(ToyFontFace('monospace'))
+    font = ScaledFont(ToyFontFace('@cairo:serif'))
+    _, _, _, _, x_advance, y_advance = font.text_extents('i' * 10)
+
+    font = ScaledFont(ToyFontFace('@cairo:monospace'))
     _, _, _, _, x_advance_mono, y_advance = font.text_extents('i' * 10)
     assert x_advance_mono > x_advance
     assert y_advance == 0
@@ -1145,7 +1146,8 @@ def test_scaled_font():
     assert isinstance(font.get_font_face(), FontFace)
 
     font = ScaledFont(
-        ToyFontFace('monospace'), Matrix(xx=20, yy=20), Matrix(xx=3, yy=.5),
+        ToyFontFace('@cairo:monospace'),
+        Matrix(xx=20, yy=20), Matrix(xx=3, yy=.5),
         FontOptions(antialias=cairocffi.ANTIALIAS_BEST))
     assert font.get_font_options().get_antialias() == cairocffi.ANTIALIAS_BEST
     assert font.get_font_matrix().as_tuple() == (20, 0, 0, 20, 0, 0)

--- a/cairocffi/test_cairo.py
+++ b/cairocffi/test_cairo.py
@@ -23,16 +23,15 @@ import tempfile
 import cairocffi
 import pytest
 
-from . import (PDF_METADATA_AUTHOR, PDF_METADATA_CREATE_DATE,
-               PDF_METADATA_CREATOR, PDF_METADATA_KEYWORDS,
-               PDF_METADATA_MOD_DATE, PDF_METADATA_SUBJECT, PDF_METADATA_TITLE,
-               PDF_OUTLINE_FLAG_BOLD, PDF_OUTLINE_FLAG_OPEN, PDF_OUTLINE_ROOT,
-               SVG_UNIT_PC, SVG_UNIT_PT, SVG_UNIT_PX, TAG_LINK, Context,
-               FontFace, FontOptions, ImageSurface, LinearGradient, Matrix,
-               Pattern, PDFSurface, PSSurface, RadialGradient,
-               RecordingSurface, ScaledFont, SolidPattern, Surface,
-               SurfacePattern, SVGSurface, ToyFontFace, cairo_version,
-               cairo_version_string)
+from . import (
+    PDF_METADATA_AUTHOR, PDF_METADATA_CREATE_DATE, PDF_METADATA_CREATOR,
+    PDF_METADATA_KEYWORDS, PDF_METADATA_MOD_DATE, PDF_METADATA_SUBJECT,
+    PDF_METADATA_TITLE, PDF_OUTLINE_FLAG_BOLD, PDF_OUTLINE_FLAG_OPEN,
+    PDF_OUTLINE_ROOT, SVG_UNIT_PC, SVG_UNIT_PT, SVG_UNIT_PX, TAG_LINK,
+    Context, FontFace, FontOptions, ImageSurface, LinearGradient, Matrix,
+    Pattern, PDFSurface, PSSurface, RadialGradient, RecordingSurface,
+    ScaledFont, SolidPattern, Surface, SurfacePattern, SVGSurface,
+    ToyFontFace, cairo_version, cairo_version_string)
 
 if sys.byteorder == 'little':
     def pixel(argb):  # pragma: no cover

--- a/cairocffi/test_xcb.py
+++ b/cairocffi/test_xcb.py
@@ -1,5 +1,4 @@
 """
-
     cairocffi.test_xcb
     ~~~~~~~~~~~~~~~~~~
 
@@ -16,10 +15,11 @@ import time
 import pytest
 
 xcffib = pytest.importorskip('xcffib')  # noqa
-import xcffib.xproto
-from xcffib.xproto import ConfigWindow, CW, EventMask, GC
 
-from . import Context, XCBSurface, cairo_version
+import xcffib.xproto  # noqa isort:skip
+from xcffib.xproto import ConfigWindow, CW, EventMask, GC  # noqa isort:skip
+
+from . import Context, XCBSurface, cairo_version  # noqa isort:skip
 
 
 @pytest.fixture

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,9 +84,7 @@ exclude =
 
 [isort]
 default_section = THIRDPARTY
-skip =
-  cairocffi/ffi_build.py
-  cairocffi/test_xcb.py
+multi_line_output = 4
 
 [coverage:report]
 exclude_lines =


### PR DESCRIPTION
Using `dlopen`'s version from WeasyPrint should be enough, as it's widely tested. It's much simpler and should help debugging in the future.

We should at least add CI for Windows and macOS before merging.