### PR TITLE
Remove pytest from setup requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,6 @@ project_urls =
 packages = find:
 setup_requires =
   cffi >= 1.1.0
-  pytest-runner
   setuptools
 install_requires =
   cffi >= 1.1.0


### PR DESCRIPTION
It's not a great package to have in production, and doesn't actually seem to be needed for anything apart from running tests.