### PR TITLE
Add NumPy support and an example to test

### DIFF
--- a/utils/numpy_example.py
+++ b/utils/numpy_example.py
@@ -1,0 +1,21 @@
+import numpy
+# import cairo
+import cairocffi as cairo
+import math
+
+data = numpy.zeros((200, 200, 4), dtype=numpy.uint8)
+surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 200, 200, data=data)
+cr = cairo.Context(surface)
+
+# fill with solid white
+cr.set_source_rgb(1.0, 1.0, 1.0)
+cr.paint()
+
+# draw red circle
+cr.arc(100, 100, 80, 0, 2*math.pi)
+cr.set_line_width(3)
+cr.set_source_rgb(1.0, 0.0, 0.0)
+cr.stroke()
+
+# write output
+surface.write_to_png("circle.png")


### PR DESCRIPTION
Relevant issues: #51 and #84

When I tried to switch `pycairo` into `cairocffi`, I met the same issues as above.

After changing some code, I can switch `pycairo` into `cairocffi` and get the correct result successfully. 😃🎉

I also added an tiny example(copied from the issues) for a quick test.

The result should be:
![circle](https://user-images.githubusercontent.com/47266984/78466529-903ad180-7734-11ea-8af0-d26c9f9a6ced.png)

I only know a little about NumPy, so I'm not sure whether it can solve all the problems about NumPy in cairocffi. 😂

But so far this changement has satisfied my purpose. And if nothing wrong, I hope you can update and release, because I want to use cairocffi in another package called manim which currently uses pycairo.