### PR TITLE
dlopen shared library symlink using major version name.

### DIFF
--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -47,7 +47,7 @@ def dlopen(ffi, library_names, filenames):
 
 cairo = dlopen(
     ffi, ('cairo', 'libcairo-2'),
-    ('libcairo.so', 'libcairo.2.dylib', 'libcairo-2.dll'))
+    ('libcairo.so.2', 'libcairo.2.dylib', 'libcairo-2.dll'))
 
 
 class _keepref(object):

--- a/cairocffi/pixbuf.py
+++ b/cairocffi/pixbuf.py
@@ -21,18 +21,18 @@ __all__ = ['decode_to_image_surface']
 
 gdk_pixbuf = dlopen(
     ffi, ('gdk_pixbuf-2.0', 'libgdk_pixbuf-2.0-0'),
-    ('libgdk_pixbuf-2.0.so', 'libgdk_pixbuf-2.0.0.dylib',
+    ('libgdk_pixbuf-2.0.so.0', 'libgdk_pixbuf-2.0.0.dylib',
      'libgdk_pixbuf-2.0-0.dll'))
 gobject = dlopen(
     ffi, ('gobject-2.0', 'libgobject-2.0-0'),
-    ('libgobject-2.0.so', 'libgobject-2.0.dylib', 'libgobject-2.0-0.dll'))
+    ('libgobject-2.0.so.0', 'libgobject-2.0.dylib', 'libgobject-2.0-0.dll'))
 glib = dlopen(
     ffi, ('glib-2.0', 'libglib-2.0-0'),
-    ('libglib-2.0.so', 'libglib-2.0.dylib', 'libglib-2.0-0.dll'))
+    ('libglib-2.0.so.0', 'libglib-2.0.dylib', 'libglib-2.0-0.dll'))
 try:
     gdk = dlopen(
         ffi, ('gdk-3', 'libgdk-3-0'),
-        ('libgdk-3.so', 'libgdk-3.0.dylib', 'libgdk-3-0.dll'))
+        ('libgdk-3.so.0', 'libgdk-3.0.dylib', 'libgdk-3-0.dll'))
 except OSError:
     gdk = None
 


### PR DESCRIPTION
cffi.dlopen should use .so.N symlinks instead of .so to
make sure we load ABI compatible version of the library and
the same library used by the rest of the system.

cffi uses `ctypes.util.find_library` to search for libraries
and the docs for `find_library` states that
"The exact functionality is system dependent."
so different system may expect different names for the same library.

To overcome that problem we try to load several names until success
among these names exact file name with `.so` suffix
eg. `libcairo.so` but .so symlink is not always safe to use.

Shared library usually consist of two of three files:
- libcairo.so.N.M - N.M exact version number
- libcairo.so.N - symlink to library.so.N.M with major ABI version
- libcairo.so - symlink to library.so.N

When -lcairo flag is used linker search for libcairo.so,
but when the programm loaded it loads libcairo.so.N where N
is the version that it was linked with.

Some downsides of .so usage:
- .so may point to the wrong ABI version, e.g. we expect libcairo
  version 2 but libcairo.so points at libcairo.so.1
- usually .so files are shipped with development packages `-dev`
  in debian and `-devel` in centos and they are just symlinks
  to the .so.N files. So it safer to search for .so.N files they
  will exist even if dev package is not installed.
- hard symlink .so -> .so.N not always preserved, eg. if we zip
  them we get two copies of the library and while the rest of the
  system will use .so.N file we will load .so files that may lead
  to crash