### PR TITLE
Add extra library Name

### DIFF
--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -46,7 +46,7 @@ def dlopen(ffi, library_names, filenames):
 
 
 cairo = dlopen(
-    ffi, ('cairo', 'libcairo-2'),
+    ffi, ('cairo-2', 'cairo', 'libcairo-2'),
     ('libcairo.so.2', 'libcairo.2.dylib', 'libcairo-2.dll'))
 
 


### PR DESCRIPTION
Today I was building the latest version of  Cairo(1.17.4) with meson and found it produced the output as `cairo-2.dll` adding it to library names.