### PR TITLE
Load DLL file using Environment variable

### DIFF
--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -9,6 +9,7 @@
 
 """
 
+import os
 import sys
 from ctypes.util import find_library
 from pathlib import Path
@@ -20,6 +21,8 @@ VERSION = __version__ = (Path(__file__).parent / 'VERSION').read_text().strip()
 # supported version of cairo, used to be pycairo version too:
 version = '1.17.2'
 version_info = (1, 17, 2)
+CAIRO_LOCATION = os.getenv('CAIRO_LOCATION')
+cairo = None
 
 
 def dlopen(ffi, library_names, filenames):
@@ -45,9 +48,17 @@ def dlopen(ffi, library_names, filenames):
     raise OSError(error_message)  # pragma: no cover
 
 
-cairo = dlopen(
-    ffi, ('cairo-2', 'cairo', 'libcairo-2'),
-    ('libcairo.so.2', 'libcairo.2.dylib', 'libcairo-2.dll'))
+if CAIRO_LOCATION:
+    try:
+        cairo = ffi.dlopen(CAIRO_LOCATION)
+    except OSError:
+        cairo = None
+if cairo is None:
+    cairo = dlopen(
+        ffi,
+        ("cairo-2", "cairo", "libcairo-2"),
+        ("libcairo.so.2", "libcairo.2.dylib", "libcairo-2.dll"),
+    )
 
 
 class _keepref(object):

--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -11,6 +11,7 @@
 
 import os
 import sys
+import warnings
 from ctypes.util import find_library
 from pathlib import Path
 
@@ -52,6 +53,7 @@ if CAIRO_LOCATION:
     try:
         cairo = ffi.dlopen(CAIRO_LOCATION)
     except OSError:
+        warnings.warn(f'Error loading {CAIRO_LOCATION}.Falling back.')
         cairo = None
 if cairo is None:
     cairo = dlopen(


### PR DESCRIPTION
Fixes https://github.com/Kozea/cairocffi/issues/170
Would be super helpful for users on windows. See #170 for the explanation.

The variable `CAIRO_LOCATION` is read and loaded first. If anything fails, a warning is issued and fallen back to searching for a library. I tested it on Windows.