### PR TITLE
Read version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,13 @@
+import os
 import sys
 
 from setuptools import setup
+
+
+VERSION_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "cairocffi", "VERSION")
+with open(VERSION_FILE, "r") as fd:
+    version = fd.read().strip()
+
 
 if sys.version_info.major < 3:
     raise RuntimeError(
@@ -8,6 +15,7 @@ if sys.version_info.major < 3:
         'Please use Python 3 or install an older version of cairocffi.')
 
 setup(
+    version=version,
     cffi_modules=[
         'cairocffi/ffi_build.py:ffi',
         'cairocffi/ffi_build.py:ffi_pixbuf']


### PR DESCRIPTION
Since October 2020, pip became more strict toward version declaration. As a result, install cairocffi with the latest version (20.3.3) fails with the following error:

```  
WARNING: Requested cairocffi>=0.9.0 from https://files.pythonhosted.org/packages/84/ca/0bffed5116d21251469df200448667e90acaa5131edea869b44a3fbc73d0/cairocffi-1.2.0.tar.gz#sha256=9a979b500c64c8179fec286f337e8fe644eca2f2cd05860ce0b62d25f22ea140 (from weasyprint), but installing version file-.cairocffi-VERSION
ERROR: Requested cairocffi>=0.9.0 from https://files.pythonhosted.org/packages/84/ca/0bffed5116d21251469df200448667e90acaa5131edea869b44a3fbc73d0/cairocffi-1.2.0.tar.gz#sha256=9a979b500c64c8179fec286f337e8fe644eca2f2cd05860ce0b62d25f22ea140 (from weasyprint) has different version in metadata: 'file-.cairocffi-VERSION'
```

This is mentioned in https://github.com/Kozea/cairocffi/issues/172, which suggests using `--use-deprecated=legacy-resolver`. This is unstable, as this flag is intended to be remove in a future release.

On the other hand, using pip 20.2.1 works, but says:

```
ERROR: After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.
```

---

As a fix, I propose to simply read the version number from `cairocffi/VERSION` in `setup.py`. I've succesfully tested this by installing my fork via pip's VCS support.

Solves #172 