### PR TITLE
Import constants.py using spec_from_file_location

### DIFF
--- a/cairocffi/ffi_build.py
+++ b/cairocffi/ffi_build.py
@@ -9,15 +9,17 @@
 
 """
 
-import sys
 from pathlib import Path
+from importlib.util import spec_from_file_location, module_from_spec
 
 from cffi import FFI
 
 # Path hack to import constants when this file is exec'd by setuptools
-sys.path.append(str(Path(__file__).parent))
-
-import constants  # noqa isort:skip
+constants_spec = spec_from_file_location(
+    'constants', Path(__file__).parent.joinpath('constants.py')
+)
+constants = module_from_spec(constants_spec)
+constants_spec.loader.exec_module(constants)
 
 # Create an empty _generated folder if needed
 (Path(__file__).parent / '_generated').mkdir(exist_ok=True)


### PR DESCRIPTION
This fixes an importing the wrong 'constants' module if you
happen to have one with the same name accesible in the PYTHONPATH

c.f https://github.com/Kozea/cairocffi/issues/176

Remove unused import