### PR TITLE
Use pikepdf to parse generated PDF

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ tests_require =
   pytest-flake8
   pytest-isort
   pytest-runner
+  pikepdf
   numpy
 python_requires = >= 3.7
 
@@ -63,6 +64,7 @@ test =
   pytest-cov
   pytest-flake8
   pytest-isort
+  pikepdf
 xcb =
   xcffib >= 0.3.2
 


### PR DESCRIPTION
This fixed the test failures with latest cairo (#204). pikepdf was
chosen because it is modern and based on a mature PDF library (qpdf).