### PR TITLE
Update __init__.py

### DIFF
--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -22,22 +22,15 @@ version = '1.17.2'
 version_info = (1, 17, 2)
 
 
-def set_dll_search_path():
-    # Python 3.8 no longer searches for DLLs in PATH, so we have to add
-    # everything in PATH manually. Note that unlike PATH add_dll_directory
-    # has no defined order, so if there are two cairo DLLs in PATH we
-    # might get a random one.
-    if os.name != "nt" or not hasattr(os, "add_dll_directory"):
-        return
-    for path in os.environ.get("PATH", "").split(os.pathsep):
-        try:
+# Python 3.8 no longer searches for DLLs in PATH, so we can add everything in
+# CAIROCFFI_DLL_DIRECTORIES manually. Note that unlike PATH, add_dll_directory
+# has no defined order, so if there are two cairo DLLs in PATH we might get a
+# random one.
+dll_directories = os.getenv('CAIROCFFI_DLL_DIRECTORIES')
+if dll_directories and hasattr(os, 'add_dll_directory'):
+    for path in dll_directories.split(';'):
+        with suppress((OSError, FileNotFoundError)):
             os.add_dll_directory(path)
-        except OSError:
-            pass
-
-
-if not find_library("libcairo-2") and sys.version_info >= (3, 8):
-    set_dll_search_path()
 
 
 def dlopen(ffi, library_names, filenames):

--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -9,6 +9,7 @@
 
 """
 
+import os
 import sys
 from ctypes.util import find_library
 
@@ -19,6 +20,24 @@ VERSION = __version__ = '1.6.1'
 # supported version of cairo, used to be pycairo version too:
 version = '1.17.2'
 version_info = (1, 17, 2)
+
+
+def set_dll_search_path():
+    # Python 3.8 no longer searches for DLLs in PATH, so we have to add
+    # everything in PATH manually. Note that unlike PATH add_dll_directory
+    # has no defined order, so if there are two cairo DLLs in PATH we
+    # might get a random one.
+    if os.name != "nt" or not hasattr(os, "add_dll_directory"):
+        return
+    for path in os.environ.get("PATH", "").split(os.pathsep):
+        try:
+            os.add_dll_directory(path)
+        except OSError:
+            pass
+
+
+if not find_library("libcairo-2") and sys.version_info >= (3, 8):
+    set_dll_search_path()
 
 
 def dlopen(ffi, library_names, filenames):

--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -11,6 +11,7 @@
 
 import os
 import sys
+from contextlib import suppress
 from ctypes.util import find_library
 
 from . import constants

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -60,8 +60,12 @@ If it fails to find it, you will see an exception like this::
 
 Make sure cairo is correctly installed and available through your system’s
 usual mechanisms.
+
 On Linux, the ``LD_LIBRARY_PATH`` environment variable can be used to indicate
 where to find shared libraries.
+
+On Windows, you can put the folder where Cairo and other DLLs are installed in
+the ``CAIROCFFI_DLL_DIRECTORIES`` environment variable.
 
 .. _Pycairo: http://cairographics.org/pycairo/
 


### PR DESCRIPTION
Python 3.8+ no longer searches for DLLs in PATH. Add paths in PATH manually. See [PyCairo Windows Python3.8 Import Issue](https://github.com/pygobject/pycairo/blob/8c5d0c700cb4b49bff1092dca498ef3e75439a26/tests/__init__.py)