### PR TITLE
Added Context.{get,set}_hairline(), according changes to ffi header, …

### DIFF
--- a/cairocffi/constants.py
+++ b/cairocffi/constants.py
@@ -482,6 +482,9 @@ cairo_set_fill_rule (cairo_t *cr, cairo_fill_rule_t fill_rule);
 void
 cairo_set_line_width (cairo_t *cr, double width);
 
+void
+cairo_set_hairline (cairo_t *cr, cairo_bool_t set_hairline);
+
 typedef enum _cairo_line_cap {
     CAIRO_LINE_CAP_BUTT,
     CAIRO_LINE_CAP_ROUND,
@@ -1097,6 +1100,9 @@ cairo_get_fill_rule (cairo_t *cr);
 
 double
 cairo_get_line_width (cairo_t *cr);
+
+cairo_bool_t
+cairo_get_hairline (cairo_t *cr);
 
 cairo_line_cap_t
 cairo_get_line_cap (cairo_t *cr);

--- a/cairocffi/context.py
+++ b/cairocffi/context.py
@@ -2259,7 +2259,8 @@ class Context(object):
     def set_hairline(self, enabled):
         """Sets lines within the cairo context to be hairlines.
 
-        Hairlines are logically zero-width lines that are drawn at the thinnest renderable width possible in the current context.
+        Hairlines are logically zero-width lines that are drawn at the thinnest
+        renderable width possible in the current context.
 
         :type enabled: bool
         :param enabled: whether or not to set hairline mode

--- a/cairocffi/context.py
+++ b/cairocffi/context.py
@@ -2255,3 +2255,25 @@ class Context(object):
         """
         cairo.cairo_tag_end(self._pointer, _encode_string(tag_name))
         self._check_status()
+
+    def set_hairline(self, enabled):
+        """Sets lines within the cairo context to be hairlines.
+
+        Hairlines are logically zero-width lines that are drawn at the thinnest renderable width possible in the current context.
+
+        :type enabled: bool
+        :param enabled: whether or not to set hairline mode
+
+        *New in cairo 1.18.*
+        """
+        cairo.cairo_set_hairline(self._pointer, int(enabled))
+        self._check_status()
+
+    def get_hairline(self):
+        """Returns whether or not hairline mode is set, as set by cairo_set_hairline().
+
+        :returns: whether hairline mode is set
+
+        *New in cairo 1.18.*
+        """
+        return bool(cairo.cairo_get_hairline(self._pointer))

--- a/cairocffi/test_cairo.py
+++ b/cairocffi/test_cairo.py
@@ -1267,3 +1267,13 @@ def test_from_null_pointer():
     for class_ in [Surface, Context, Pattern, FontFace, ScaledFont]:
         with pytest.raises(ValueError):
             class_._from_pointer(cairocffi.ffi.NULL, 'unused')
+
+
+def test_hairline():
+    for extents in [None, (0, 0, 140, 80)]:
+        surface = RecordingSurface(cairocffi.CONTENT_COLOR_ALPHA, extents)
+        ctx = Context(surface)
+        ctx.set_hairline(True)
+        assert(ctx.get_hairline() is True)
+        ctx.set_hairline(False)
+        assert(ctx.get_hairline() is False)

--- a/cairocffi/test_cairo.py
+++ b/cairocffi/test_cairo.py
@@ -1269,6 +1269,8 @@ def test_from_null_pointer():
             class_._from_pointer(cairocffi.ffi.NULL, 'unused')
 
 
+@pytest.mark.xfail(cairo_version() < 11800,
+                   reason='Cairo version too low')
 def test_hairline():
     for extents in [None, (0, 0, 140, 80)]:
         surface = RecordingSurface(cairocffi.CONTENT_COLOR_ALPHA, extents)


### PR DESCRIPTION
…and test case.