### PR TITLE
Api mode cffi compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 __pycache__
+_*.o
+_*.so
+_*.c
 cairocffi/_ffi*.py
 *.egg
 *.egg-info

--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -40,7 +40,7 @@ if api_mode:
 
 # Fall back to non api mode
 if not api_mode:
-    from .ffi import ffi  # noqa
+    from .ffi_build import ffi  # noqa
 
     # Python 3.8 no longer searches for DLLs in PATH, so we can add everything in
     # CAIROCFFI_DLL_DIRECTORIES manually. Note that unlike PATH, add_dll_directory

--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -17,7 +17,7 @@ from ctypes.util import find_library
 from . import constants
 
 
-VERSION = __version__ = '1.7.1'
+VERSION = __version__ = '1.7.2'
 # supported version of cairo, used to be pycairo version too:
 version = '1.17.2'
 version_info = (1, 17, 2)

--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -15,51 +15,63 @@ from contextlib import suppress
 from ctypes.util import find_library
 
 from . import constants
-from .ffi import ffi
+
+
+api_mode = False
+try:
+    from _cairocffi import lib as cairo
+    from _cairocffi import ffi
+    api_mode = True
+except ImportError as e:
+    print("bobo",e)
+    api_mode = False
+
+if not api_mode:
+    from .ffi import ffi  # noqa
 
 VERSION = __version__ = '1.7.1'
 # supported version of cairo, used to be pycairo version too:
 version = '1.17.2'
 version_info = (1, 17, 2)
 
-
-# Python 3.8 no longer searches for DLLs in PATH, so we can add everything in
-# CAIROCFFI_DLL_DIRECTORIES manually. Note that unlike PATH, add_dll_directory
-# has no defined order, so if there are two cairo DLLs in PATH we might get a
-# random one.
-dll_directories = os.getenv('CAIROCFFI_DLL_DIRECTORIES')
-if dll_directories and hasattr(os, 'add_dll_directory'):
-    for path in dll_directories.split(';'):
-        with suppress((OSError, FileNotFoundError)):
-            os.add_dll_directory(path)
-
-
-def dlopen(ffi, library_names, filenames):
-    """Try various names for the same library, for different platforms."""
-    exceptions = []
-
-    for library_name in library_names:
-        library_filename = find_library(library_name)
-        if library_filename:
-            filenames = (library_filename, *filenames)
-        else:
-            exceptions.append(
-                'no library called "{}" was found'.format(library_name))
-
-    for filename in filenames:
-        try:
-            return ffi.dlopen(filename)
-        except OSError as exception:  # pragma: no cover
-            exceptions.append(exception)
-
-    error_message = '\n'.join(  # pragma: no cover
-        str(exception) for exception in exceptions)
-    raise OSError(error_message)  # pragma: no cover
+if not api_mode:
+    # Python 3.8 no longer searches for DLLs in PATH, so we can add everything in
+    # CAIROCFFI_DLL_DIRECTORIES manually. Note that unlike PATH, add_dll_directory
+    # has no defined order, so if there are two cairo DLLs in PATH we might get a
+    # random one.
+    dll_directories = os.getenv('CAIROCFFI_DLL_DIRECTORIES')
+    if dll_directories and hasattr(os, 'add_dll_directory'):
+        for path in dll_directories.split(';'):
+            with suppress((OSError, FileNotFoundError)):
+                os.add_dll_directory(path)
 
 
-cairo = dlopen(
-    ffi, ('cairo-2', 'cairo', 'libcairo-2'),
-    ('libcairo.so.2', 'libcairo.2.dylib', 'libcairo-2.dll'))
+    def dlopen(ffi, library_names, filenames):
+        """Try various names for the same library, for different platforms."""
+        exceptions = []
+
+        for library_name in library_names:
+            library_filename = find_library(library_name)
+            if library_filename:
+                filenames = (library_filename, *filenames)
+            else:
+                exceptions.append(
+                    'no library called "{}" was found'.format(library_name))
+
+        for filename in filenames:
+            try:
+                return ffi.dlopen(filename)
+            except OSError as exception:  # pragma: no cover
+                exceptions.append(exception)
+
+        error_message = '\n'.join(  # pragma: no cover
+            str(exception) for exception in exceptions)
+        raise OSError(error_message)  # pragma: no cover
+
+
+    cairo = dlopen(
+        ffi, ('cairo-2', 'cairo', 'libcairo-2'),
+        ('libcairo.so.2', 'libcairo.2.dylib', 'libcairo-2.dll'))
 
 
 class _keepref(object):  # noqa: N801

--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -19,11 +19,10 @@ from . import constants
 
 api_mode = False
 try:
-    from _cairocffi import lib as cairo
     from _cairocffi import ffi
+    from _cairocffi import lib as cairo
     api_mode = True
-except ImportError as e:
-    print("bobo",e)
+except ImportError:
     api_mode = False
 
 if not api_mode:

--- a/cairocffi/constants.py
+++ b/cairocffi/constants.py
@@ -457,12 +457,12 @@ cairo_set_tolerance (cairo_t *cr, double tolerance);
 typedef enum _cairo_antialias {
     CAIRO_ANTIALIAS_DEFAULT,
 
-    
+
     CAIRO_ANTIALIAS_NONE,
     CAIRO_ANTIALIAS_GRAY,
     CAIRO_ANTIALIAS_SUBPIXEL,
 
-    
+
     CAIRO_ANTIALIAS_FAST,
     CAIRO_ANTIALIAS_GOOD,
     CAIRO_ANTIALIAS_BEST
@@ -1827,9 +1827,9 @@ cairo_matrix_transform_point (const cairo_matrix_t *matrix,
 typedef struct _cairo_region cairo_region_t;
 
 typedef enum _cairo_region_overlap {
-    CAIRO_REGION_OVERLAP_IN,		
-    CAIRO_REGION_OVERLAP_OUT,		
-    CAIRO_REGION_OVERLAP_PART		
+    CAIRO_REGION_OVERLAP_IN,
+    CAIRO_REGION_OVERLAP_OUT,
+    CAIRO_REGION_OVERLAP_PART
 } cairo_region_overlap_t;
 
 cairo_region_t *
@@ -2085,11 +2085,12 @@ cairo_svg_surface_set_document_unit (cairo_surface_t	*surface,
 cairo_svg_unit_t
 cairo_svg_surface_get_document_unit (cairo_surface_t	*surface);
 
+"""
 
+_CAIRO_WIN32_HEADERS = r"""
         typedef void* HDC;
         typedef void* HFONT;
         typedef void LOGFONTW;
-    
 
 cairo_surface_t *
 cairo_win32_surface_create (HDC hdc);
@@ -2133,6 +2134,7 @@ cairo_win32_scaled_font_select_font (cairo_scaled_font_t *scaled_font,
 
 void
 cairo_win32_scaled_font_done_font (cairo_scaled_font_t *scaled_font);
+:w
 
 double
 cairo_win32_scaled_font_get_metrics_factor (cairo_scaled_font_t *scaled_font);
@@ -2144,12 +2146,13 @@ cairo_win32_scaled_font_get_logical_to_device (cairo_scaled_font_t *scaled_font,
 void
 cairo_win32_scaled_font_get_device_to_logical (cairo_scaled_font_t *scaled_font,
 					       cairo_matrix_t *device_to_logical);
+"""
 
-
+_CAIRO_QUARTZ_HEADERS = r"""
         typedef void* CGContextRef;
         typedef void* CGFontRef;
-        typedef void* ATSUFontID;
-    
+        typedef unsigned int ATSUFontID;
+
 
 cairo_surface_t *
 cairo_quartz_surface_create (cairo_format_t format,

--- a/cairocffi/ffi.py
+++ b/cairocffi/ffi.py
@@ -43,9 +43,8 @@ try:
 except ImportError:
     pass
 else:
-    pass
-    #ffi.include(xcb_ffi)
-    #ffi.cdef(constants._CAIRO_XCB_HEADERS)
+    ffi.include(xcb_ffi)
+    ffi.cdef(constants._CAIRO_XCB_HEADERS)
 
 # gdk pixbuf cffi definitions
 ffi_pixbuf = FFI()

--- a/cairocffi/ffi.py
+++ b/cairocffi/ffi.py
@@ -9,13 +9,19 @@
 
 """
 
+import platform
+
 from cffi import FFI
 
-from . import constants
+import constants
 
 # Primary cffi definitions
 ffi = FFI()
 ffi.cdef(constants._CAIRO_HEADERS)
+if platform.system() == 'Windows':
+    ffi.cdef(constants._CAIRO_WIN32_HEADERS)
+if platform.system() == 'Darwin':
+    ffi.cdef(constants._CAIRO_QUARTZ_HEADERS)
 
 # include xcffib cffi definitions for cairo xcb support
 try:
@@ -88,3 +94,26 @@ ffi_pixbuf.cdef('''
     void              g_error_free                   (GError *error);
     void              g_type_init                    (void);
 ''')
+
+ffi.set_source_pkgconfig(
+    '_cairocffi',
+    ['cairo', 'xcb'],
+    """
+    #include "cairo.h"
+    #include "cairo-pdf.h"
+    #include "cairo-svg.h"
+    #include "cairo-ps.h"
+    #include "cairo-quartz.h"
+    #include "cairo-ft.h"
+    #include "xcb/xcb.h"
+    #include "xcb/xproto.h"
+    #include "xcb/xevie.h"
+    #include "xcb/xcbext.h"
+    #include "xcb/render.h"
+    #include "cairo-xcb.h"
+    """,
+    sources=[]
+)
+
+if __name__ == "__main__":
+    ffi.compile(verbose=True)

--- a/cairocffi/ffi.py
+++ b/cairocffi/ffi.py
@@ -10,6 +10,7 @@
 """
 
 import importlib.util
+import os
 import platform
 import sys
 from pathlib import Path
@@ -42,8 +43,9 @@ try:
 except ImportError:
     pass
 else:
-    ffi.include(xcb_ffi)
-    ffi.cdef(constants._CAIRO_XCB_HEADERS)
+    pass
+    #ffi.include(xcb_ffi)
+    #ffi.cdef(constants._CAIRO_XCB_HEADERS)
 
 # gdk pixbuf cffi definitions
 ffi_pixbuf = FFI()
@@ -108,25 +110,27 @@ ffi_pixbuf.cdef('''
     void              g_type_init                    (void);
 ''')
 
-ffi.set_source_pkgconfig(
-    '_cairocffi',
-    ['cairo', 'xcb'],
-    """
-    #include "cairo.h"
-    #include "cairo-pdf.h"
-    #include "cairo-svg.h"
-    #include "cairo-ps.h"
-    #include "cairo-quartz.h"
-    #include "cairo-ft.h"
-    #include "xcb/xcb.h"
-    #include "xcb/xproto.h"
-    #include "xcb/xevie.h"
-    #include "xcb/xcbext.h"
-    #include "xcb/render.h"
-    #include "cairo-xcb.h"
-    """,
-    sources=[]
-)
+if ('CAIROCFFI_API_MODE' in os.environ and
+        int(os.environ['CAIROCFFI_API_MODE']) == 1):
+    ffi.set_source_pkgconfig(
+        '_cairocffi',
+        ['cairo', 'xcb'],
+        """
+        #include "cairo.h"
+        #include "cairo-pdf.h"
+        #include "cairo-svg.h"
+        #include "cairo-ps.h"
+        #include "cairo-quartz.h"
+        #include "cairo-ft.h"
+        #include "xcb/xcb.h"
+        #include "xcb/xproto.h"
+        #include "xcb/xevie.h"
+        #include "xcb/xcbext.h"
+        #include "xcb/render.h"
+        #include "cairo-xcb.h"
+        """,
+        sources=[]
+    )
 
-if __name__ == "__main__":
-    ffi.compile(verbose=True)
+    if __name__ == "__main__":
+        ffi.compile(verbose=True)

--- a/cairocffi/ffi.py
+++ b/cairocffi/ffi.py
@@ -9,11 +9,24 @@
 
 """
 
+import importlib.util
 import platform
+import sys
+from pathlib import Path
 
 from cffi import FFI
 
-import constants
+
+# import constants
+# without loading the module via import which would invoke __init__.py
+sys.path.append(str(Path(__file__).parent))
+spec = importlib.util.spec_from_file_location(
+    'constants',
+    str(Path(__file__).parent / 'constants.py')
+)
+constants = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(constants)
+
 
 # Primary cffi definitions
 ffi = FFI()

--- a/cairocffi/ffi_build.py
+++ b/cairocffi/ffi_build.py
@@ -39,7 +39,7 @@ if platform.system() == 'Darwin':
 
 # include xcffib cffi definitions for cairo xcb support
 try:
-    from xcffib.ffi import ffi as xcb_ffi
+    from xcffib.ffi_build import ffi as xcb_ffi
 except ImportError:
     pass
 else:

--- a/cairocffi/ffi_build.py
+++ b/cairocffi/ffi_build.py
@@ -125,7 +125,6 @@ if ('CAIROCFFI_API_MODE' in os.environ and
         #include "cairo-ft.h"
         #include "xcb/xcb.h"
         #include "xcb/xproto.h"
-        /* #include "xcb/xevie.h" */
         #include "xcb/xcbext.h"
         #include "xcb/render.h"
         #include "cairo-xcb.h"

--- a/cairocffi/ffi_build.py
+++ b/cairocffi/ffi_build.py
@@ -114,7 +114,7 @@ if ('CAIROCFFI_API_MODE' in os.environ and
     ffi.set_source_pkgconfig(
         '_cairocffi',
         ['cairo', 'xcb'],
-        """
+        r"""
         #include "cairo.h"
         #include "cairo-pdf.h"
         #include "cairo-svg.h"
@@ -129,14 +129,23 @@ if ('CAIROCFFI_API_MODE' in os.environ and
         #include "xcb/render.h"
         #include "cairo-xcb.h"
         /* Deal with some newer definitions for compatibility */
-        #if !defined(CAIRO_FORMAT_RGBA128F)
+        #if CAIRO_VERSION < 11702
         #define CAIRO_FORMAT_RGBA128F 7
-        #endif
-        #if !defined(CAIRO_FORMAT_RGB96F)
         #define CAIRO_FORMAT_RGB96F 6
         #endif
+        #if CAIRO_VERSION < 11800
+        #include <stdio.h>
+        #include <stdbool.h>
         void cairo_set_hairline(cairo_t*, cairo_bool_t);
         cairo_bool_t cairo_get_hairline(cairo_t*);
+        void cairo_set_hairline(cairo_t*, cairo_bool_t) {
+            fprintf(stderr, "Unimplemented!!\n");
+        }
+        cairo_bool_t cairo_get_hairline(cairo_t*) {
+            fprintf(stderr, "Unimplemented!!\n");
+            return false;
+        }
+        #endif
         """,
         sources=[]
     )

--- a/cairocffi/ffi_build.py
+++ b/cairocffi/ffi_build.py
@@ -119,14 +119,25 @@ if ('CAIROCFFI_API_MODE' in os.environ and
         #include "cairo-pdf.h"
         #include "cairo-svg.h"
         #include "cairo-ps.h"
+        #if defined(__APPLE__)
         #include "cairo-quartz.h"
+        #endif
         #include "cairo-ft.h"
         #include "xcb/xcb.h"
         #include "xcb/xproto.h"
-        #include "xcb/xevie.h"
+        /* #include "xcb/xevie.h" */
         #include "xcb/xcbext.h"
         #include "xcb/render.h"
         #include "cairo-xcb.h"
+        /* Deal with some newer definitions for compatibility */
+        #if !defined(CAIRO_FORMAT_RGBA128F)
+        #define CAIRO_FORMAT_RGBA128F 7
+        #endif
+        #if !defined(CAIRO_FORMAT_RGB96F)
+        #define CAIRO_FORMAT_RGB96F 6
+        #endif
+        void cairo_set_hairline(cairo_t*, cairo_bool_t);
+        cairo_bool_t cairo_get_hairline(cairo_t*);
         """,
         sources=[]
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ readme = {file = 'README.rst', content-type = 'text/x-rst'}
 license = {file = 'LICENSE'}
 dependencies = [
     'cffi >= 1.1.0',
+    'xcffib >= 1.5.1'
 ]
 classifiers = [
     'Development Status :: 5 - Production/Stable',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ['flit_core >=3.2,<4']
-build-backend = 'flit_core.buildapi'
+requires = ["setuptools >= 64"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = 'cairocffi'
@@ -57,3 +57,6 @@ omit = ['.*']
 [tool.ruff.lint]
 select = ['E', 'W', 'F', 'I', 'N', 'RUF']
 ignore = ['RUF001', 'RUF002', 'RUF003']
+
+[tool.setuptools_scm]
+

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ if ('CAIROCFFI_API_MODE' in os.environ and
 setup(
     name='cairocffi',
     use_scm_version=True,
-    install_requires=['cffi >= 1.1.0'],
-    setup_requires=['setuptools_scm', 'cffi >= 1.1.0'],
+    install_requires=['cffi >= 1.1.0', 'xcffib'],
+    setup_requires=['setuptools_scm', 'cffi >= 1.1.0', 'xcffib'],
     packages=['cairocffi'] if api_mode else [],
-    cffi_modules=['cairocffi/ffi.py:ffi']
+    cffi_modules=['cairocffi/ffi_build.py:ffi']
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+from setuptools import setup
+from setuptools.command.install import install
+from distutils.command.build import build
+
+setup(
+    name='cairocffi',
+    use_scm_version=True,
+    install_requires=['cffi >= 1.1.0'],
+    setup_requires=['setuptools_scm', 'cffi >= 1.1.0'],
+    cffi_modules=['cairocffi/ffi.py:ffi'],
+)

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,22 @@ from setuptools import setup
 from setuptools.command.install import install
 from distutils.command.build import build
 
-setup(
-    name='cairocffi',
-    use_scm_version=True,
-    install_requires=['cffi >= 1.1.0'],
-    setup_requires=['setuptools_scm', 'cffi >= 1.1.0'],
-    cffi_modules=['cairocffi/ffi.py:ffi'],
-)
+
+if ('CAIROCFFI_API_MODE' in os.environ and
+        int(os.environ['CAIROCFFI_API_MODE']) == 1):
+    setup(
+        name='cairocffi',
+        use_scm_version=True,
+        install_requires=['cffi >= 1.1.0'],
+        setup_requires=['setuptools_scm', 'cffi >= 1.1.0'],
+        cffi_modules=['cairocffi/ffi.py:ffi'],
+        packages=['cairocffi']
+    )
+else:
+    setup(
+        name='cairocffi',
+        use_scm_version=True,
+        install_requires=['cffi >= 1.1.0'],
+        setup_requires=['setuptools_scm', 'cffi >= 1.1.0'],
+        packages=['cairocffi']
+    )

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,10 @@ if ('CAIROCFFI_API_MODE' in os.environ and
 
 setup(
     name='cairocffi',
-    use_scm_version=True,
-    install_requires=['cffi >= 1.1.0', 'xcffib'],
-    setup_requires=['setuptools_scm', 'cffi >= 1.1.0', 'xcffib'],
+    #use_scm_version=True,
+    version='1.7.2',
+    install_requires=['cffi >= 1.1.0', 'xcffib >= 1.5.1'],
+    setup_requires=['setuptools_scm', 'cffi >= 1.1.0', 'xcffib >= 1.5.1'],
     packages=['cairocffi'] if api_mode else [],
     cffi_modules=['cairocffi/ffi_build.py:ffi']
 )

--- a/setup.py
+++ b/setup.py
@@ -6,21 +6,16 @@ from setuptools.command.install import install
 from distutils.command.build import build
 
 
+api_mode = False
 if ('CAIROCFFI_API_MODE' in os.environ and
         int(os.environ['CAIROCFFI_API_MODE']) == 1):
-    setup(
-        name='cairocffi',
-        use_scm_version=True,
-        install_requires=['cffi >= 1.1.0'],
-        setup_requires=['setuptools_scm', 'cffi >= 1.1.0'],
-        cffi_modules=['cairocffi/ffi.py:ffi'],
-        packages=['cairocffi']
-    )
-else:
-    setup(
-        name='cairocffi',
-        use_scm_version=True,
-        install_requires=['cffi >= 1.1.0'],
-        setup_requires=['setuptools_scm', 'cffi >= 1.1.0'],
-        packages=['cairocffi']
-    )
+    api_mode = True
+
+setup(
+    name='cairocffi',
+    use_scm_version=True,
+    install_requires=['cffi >= 1.1.0'],
+    setup_requires=['setuptools_scm', 'cffi >= 1.1.0'],
+    packages=['cairocffi'] if api_mode else [],
+    cffi_modules=['cairocffi/ffi.py:ffi']
+)


### PR DESCRIPTION
Cffi code is much faster when compiled with a c compiler (API mode) rather than using libfffi (ABI mode) - however this requires a compiler to be installed .

This change allows an install to be made using

`CAIROCFFI_API_MODE=1 XCFFIB_API_MODE=1 pip3 install cairocffi`

Various other projects (pangocffi and pangocairocffi) can then benefit from similar changes.

This change requires xcffib changes to be accepted - see [here](https://github.com/tych0/xcffib/pull/169)

During installation `CAIROCFFI_API_MODE=0` or `CAIROCFFI_API_MODE` not set defaults to the previous ABI mode install which incurs lever overhead on load, runs the ffi_build as before and will dynamically translate arguments to C using the general libffi.

During installation `CAIROCFFI_API_MODE=1` compiles a shared library / C extension which dynamically depends on xcd.

At runtime if the shared library / C extension is present it will be used (unless `CAIROCFFI_API_MODE =0`). The user does not have to arrange for `CAIROCFFI_API_MODE =1` to be set. If the extension is not present, the old behavior is used.

To make this work I  added the relevant FFI calls / setup.py calls to have the C extension be built.

I don't suggest this be default, but API mode is a potential substantial performance improvement.  It also allows full speed threading as the C side unlocks the GIL.