### PR TITLE
on windows, libxcb is normally not available. trying to dlopen a non-…

### DIFF
--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -135,7 +135,7 @@ from .surfaces import (  # noqa isort:skip
     Win32Surface, Win32PrintingSurface)
 try:
     from .xcb import XCBSurface  # noqa isort:skip
-except ImportError:
+except (ImportError, OSError):
     pass
 from .patterns import (  # noqa isort:skip
     Pattern, SolidPattern, SurfacePattern, Gradient, LinearGradient,

--- a/cairocffi/ffi.py
+++ b/cairocffi/ffi.py
@@ -20,7 +20,7 @@ ffi.cdef(constants._CAIRO_HEADERS)
 # include xcffib cffi definitions for cairo xcb support
 try:
     from xcffib.ffi import ffi as xcb_ffi
-except ImportError:
+except (ImportError, OSError):
     pass
 else:
     ffi.include(xcb_ffi)


### PR DESCRIPTION
…existent file results in an OSError

so catch that error as well as a possible import error.